### PR TITLE
Kafka init service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+.vscode
 
 HELP.md
 target/
@@ -60,3 +61,6 @@ next-env.d.ts
 !.vscode/extensions.json
 
 dist
+
+# Python
+.venv

--- a/apps/kafka-init/.env.example
+++ b/apps/kafka-init/.env.example
@@ -1,0 +1,2 @@
+# Kafka bootstrap listener within docker network
+KAFKA_BOOTSTRAP=kafka:9092

--- a/apps/kafka-init/Dockerfile
+++ b/apps/kafka-init/Dockerfile
@@ -1,0 +1,16 @@
+#syntax=docker/dockerfile:1
+
+# Very basic build, copy requirements, upgrade pip and install deps, run init script, exit
+
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python3", "kafka_init.py"]

--- a/apps/kafka-init/kafka_init.py
+++ b/apps/kafka-init/kafka_init.py
@@ -1,0 +1,41 @@
+import sys
+import os
+from confluent_kafka.cimpl import NewTopic
+from confluent_kafka.admin import AdminClient
+
+# Try env var, fall back to default
+broker = os.getenv("KAFKA_BOOTSTRAP")
+if broker == None:
+    broker = "kafka:9092"
+
+# Attempt to connect to kafka, if timeout, wait 2 seconds then retry
+admin = AdminClient({
+    "bootstrap.servers": broker,
+    "retries": 5,
+    "retry.backoff": 2000,
+})
+
+# CloudSherpa kafka topics are configured here
+topics = [
+    NewTopic("cloud-usage-events", num_partitions=1, replication_factor=1)
+]
+
+# Returns dict[str, concurrent.futures.Future] -> topics created asynchronously
+fs = admin.create_topics(topics)
+
+for topic, f in fs.items():
+    try:
+        # Calling f.result() blocks until Kafka responds with None if succesfull or throws an error on failure
+        # Without calling f.result(), we do not know the outcome of the topic creation
+        f.result()
+        print(f"Created {topic}")
+    except Exception as e:
+        # f.result() throws a TOPIC_ALREADY_EXISTS error if the topic already exists on the broker, handle
+        # gracefully. Else rethrow and fail.
+        if "TOPIC_ALREADY_EXISTS" in str(e):
+            print(f"Topic {topic} already exists")
+        else:
+            raise
+
+# Exit cleanly to stop init service
+sys.exit(0)

--- a/apps/kafka-init/requirements.txt
+++ b/apps/kafka-init/requirements.txt
@@ -1,0 +1,1 @@
+confluent-kafka==2.14.0

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -27,6 +27,19 @@ services:
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
   
+  kafka-init:
+    build:
+      context: ../apps/kafka-init
+      dockerfile: Dockerfile
+    image: cloudsherpa-kafka-init
+    container_name: kafka-init
+    depends_on:
+      - kafka
+    restart: "no"
+    env_file:
+      - "../apps/kafka-init/.env"
+
+
   schema-registry:
       image: confluentinc/cp-schema-registry:8.0.0
       container_name: schema-registry


### PR DESCRIPTION
### TL;DR
All CloudSherpa Kafka topics defined in python list in `apps/kafka-init/kafka_init.py` 

### Kafka Init Service
Added a Kafka initialization service to reliably define topics and have them created if not created on the Kafka cluster reliably. The alternative is to manually exec into kafka controller docker container and create topics using the kafka CLI.  With the init service, all topics can be defined under `apps/kafka-init/kafka_init.py` in the topics list. Let me know if              you think this should be decentralized, i.e. we define topics in a JSON file and that gets loaded & serialized in init script. 

### `.gitignore` additions
Added `.vscode` and `.venv` to gitignore, I used python venv to test init service and if I got the dependency in requirements.txt correct. I instructed vscode to look in venv for installed pip packages for autocomplete etc. Lmk if you want me to create a CloudSherpa repo vscode settings.json. 