### PR TITLE
Setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,27 @@ CloudSherpa is an AI-driven cloud cost optimization platform designed to analyze
 
 As organizations migrate to cloud-native environments, managing resource efficiency is a significant challenge. CloudSherpa acts as a set of financial guardrails by collecting operational monitoring and billing data, and applying machine learning models to detect anomalies and predict future costs. Through an interactive web-based dashboard, users can visualize resource usage, forecast spending, and receive intelligent optimization recommendations to support data-driven cloud management decisions.
 
+## Running the Project
+
+CloudSherpa runs locally through Docker Compose. From the repository root, initialize local environment files once:
+
+```bash
+cd scripts
+chmod +x env-init.sh
+./env-init.sh
+cd ..
+```
+
+Then start the stack:
+
+```bash
+docker compose -f infra/docker-compose.yml up --build
+```
+
+The dashboard frontend is available at `http://localhost:3000`.
+
+For development workflows, individual service commands, ports, and troubleshooting, see [`docs/dev/CheatSheet.md`](docs/dev/CheatSheet.md), [`infra/README.md`](infra/README.md), and the app-specific READMEs under [`apps/`](apps/).
+
 ## Current Status & Branch Strategy
 
 **Status: Active Development**

--- a/apps/alert-engine/README.md
+++ b/apps/alert-engine/README.md
@@ -1,19 +1,19 @@
-# Dashboard Frontend
+# Alert Engine
 
-Next.js frontend for the CloudSherpa dashboard.
+Lightweight TypeScript/Express service responsible for alert-related functionality.
 
 ## Runtime
 
 - Node.js 20
-- Next.js 16
-- React 19
+- Express
+- TypeScript
 - Default local port: `3000`
-- Docker Compose host port: `3000`
+- Docker Compose host port: `3002`
 
 ## Local Setup
 
 ```bash
-cd apps/dashboard-frontend
+cd apps/alert-engine
 npm install
 ```
 
@@ -25,7 +25,7 @@ Environment files are initialized repo-wide by `scripts/env-init.sh`. Once that 
 npm run dev
 ```
 
-The Next.js dev server starts on `http://localhost:3000` unless a different port is provided.
+The dev server uses `ts-node-dev` and restarts when files under `src/` change.
 
 ## Build and Production Run
 
@@ -34,12 +34,12 @@ npm run build
 npm start
 ```
 
-The production start script serves the built Next.js app on port `3000`.
+The production command runs the compiled entrypoint at `dist/server.js`.
 
-## Lint
+## Tests
 
 ```bash
-npm run lint
+npm test
 ```
 
 ## Docker
@@ -47,17 +47,17 @@ npm run lint
 From the repository root:
 
 ```bash
-docker compose -f infra/docker-compose.yml up --build dashboard-frontend
+docker compose -f infra/docker-compose.yml up --build alert-engine
 ```
 
 ## Dev Dependencies
 
-This app uses development-only packages for:
+This service uses development-only packages for:
 
-- TypeScript types: `@types/node`, `@types/react`, `@types/react-dom`
-- Linting: `eslint`, `eslint-config-next`
-- Styling pipeline: `tailwindcss`, `@tailwindcss/postcss`
-- TypeScript: `typescript`
+- TypeScript compilation: `typescript`
+- Hot reload: `ts-node-dev`
+- Testing: `jest`, `ts-jest`, `supertest`
+- Type definitions: `@types/*`
 
 Install all dependencies with `npm install` for local development. The Docker production image installs runtime dependencies only with `npm ci --omit=dev`.
 
@@ -68,10 +68,5 @@ Local environment values should live in `.env`. Keep committed defaults and docu
 ### Development
 
 - If `scripts/env-init.sh` has already been run, the local `.env` file should be in place.
-- Client-exposed values must use the `NEXT_PUBLIC_` prefix.
-- Point API URLs at the local dashboard backend, usually `http://localhost:3001`.
-
-### Production
-
-- Build with production API URLs.
-- Run with `NODE_ENV=production`.
+- Use localhost service addresses when running dependencies on the host.
+- Use Docker service names such as `kafka` when running inside Docker Compose.

--- a/apps/analytics-engine/README.md
+++ b/apps/analytics-engine/README.md
@@ -19,10 +19,10 @@ chmod +x mvnw
 
 Environment files are initialized repo-wide by `scripts/env-init.sh`. Once that script has been run, this service should already have the `.env` file it needs for local development.
 
-If the service needs Kafka locally, start the shared development dependencies from the repository root:
+If the service needs Kafka locally, start the shared development dependencies and initialize topics from the repository root:
 
 ```bash
-docker compose -f infra/docker-compose.yml up -d kafka schema-registry
+docker compose -f infra/docker-compose.yml up -d --build kafka kafka-init schema-registry
 ```
 
 ## Development Server

--- a/apps/analytics-engine/README.md
+++ b/apps/analytics-engine/README.md
@@ -1,0 +1,84 @@
+# Analytics Engine
+
+Spring Boot service responsible for analytics workflows over normalized cost and usage data.
+
+## Runtime
+
+- Java 21
+- Spring Boot 3.5
+- Maven Wrapper
+- Container port: `8080`
+- Docker Compose host port: `8083`
+
+## Local Setup
+
+```bash
+cd apps/analytics-engine
+chmod +x mvnw
+```
+
+Environment files are initialized repo-wide by `scripts/env-init.sh`. Once that script has been run, this service should already have the `.env` file it needs for local development.
+
+If the service needs Kafka locally, start the shared development dependencies from the repository root:
+
+```bash
+docker compose -f infra/docker-compose.yml up -d kafka schema-registry
+```
+
+## Development Server
+
+```bash
+./mvnw spring-boot:run
+```
+
+Spring Boot runs on port `8080` by default unless `SERVER_PORT` or application configuration overrides it.
+
+## Build and Production Run
+
+```bash
+./mvnw clean package
+java -jar target/*.jar
+```
+
+To skip tests during a local packaging pass:
+
+```bash
+./mvnw clean package -DskipTests
+```
+
+## Tests
+
+```bash
+./mvnw test
+```
+
+## Docker
+
+From the repository root:
+
+```bash
+docker compose -f infra/docker-compose.yml up --build analytics-engine
+```
+
+## Dev Dependencies
+
+Maven resolves development and test dependencies from `pom.xml`.
+
+Key development dependencies include:
+
+- Spring Boot test support: `spring-boot-starter-test`
+- Kafka test support: `spring-kafka-test`
+- Maven Wrapper files: `mvnw` and `.mvn/wrapper`
+
+Do not commit generated Maven output from `target/`. (the `.gitignore` enforces this)
+
+## Environment Configuration
+
+Local environment values should live in `.env`. Keep committed defaults and documentation in `.env.example`. Use `scripts/env-init.sh` to copy `.env.example` files into `.env` files across the repo.
+
+### Development
+
+- If `scripts/env-init.sh` has already been run, the local `.env` file should be in place.
+- Use `localhost:29092` for Kafka when the app runs on the host.
+- Use `kafka:9092` for Kafka when the app runs inside Docker Compose.
+- Keep development-only overrides out of `application.properties` unless they are safe defaults.

--- a/apps/dashboard-backend/README.md
+++ b/apps/dashboard-backend/README.md
@@ -1,0 +1,88 @@
+# Dashboard Backend
+
+NestJS backend API for the CloudSherpa dashboard. This service acts as the backend-for-frontend for dashboard screens.
+
+## Runtime
+
+- Node.js 20
+- NestJS
+- TypeScript
+- Default local port: `3001`
+- Docker Compose host port: `3001`
+
+## Local Setup
+
+```bash
+cd apps/dashboard-backend
+npm install
+```
+
+Environment files are initialized repo-wide by `scripts/env-init.sh`. Once that script has been run, this service should already have the `.env` file it needs for local development.
+
+## Development Server
+
+```bash
+npm run start:dev
+```
+
+The development server runs Nest in watch mode.
+
+## Build and Production Run
+
+```bash
+npm run build
+npm run start:prod
+```
+
+The production command runs the compiled entrypoint from `dist/`.
+
+## Tests
+
+```bash
+npm test
+npm run test:e2e
+```
+
+Additional test commands:
+
+```bash
+npm run test:watch
+npm run test:cov
+```
+
+## Lint and Format
+
+```bash
+npm run lint
+npm run format
+```
+
+## Docker
+
+From the repository root:
+
+```bash
+docker compose -f infra/docker-compose.yml up --build dashboard-backend
+```
+
+## Dev Dependencies
+
+This service uses development-only packages for:
+
+- Nest CLI and schematics: `@nestjs/cli`, `@nestjs/schematics`
+- TypeScript build tooling: `typescript`, `ts-node`, `ts-loader`, `tsconfig-paths`
+- Testing: `jest`, `ts-jest`, `supertest`, `@nestjs/testing`
+- Linting and formatting: `eslint`, `prettier`, `typescript-eslint`
+- Type definitions: `@types/*`
+
+Install all dependencies with `npm install` for local development. The Docker production image installs runtime dependencies only with `npm ci --omit=dev`.
+
+## Environment Configuration
+
+Local environment values should live in `.env`. Keep committed defaults and documentation in `.env.example`. Use `scripts/env-init.sh` to copy `.env.example` files into `.env` files across the repo.
+
+### Development
+
+- If `scripts/env-init.sh` has already been run, the local `.env` file should be in place.
+- Use localhost URLs for services running on the host.
+- Use Docker service names when running through Docker Compose.

--- a/apps/ingestion-service/README.md
+++ b/apps/ingestion-service/README.md
@@ -19,10 +19,10 @@ chmod +x mvnw
 
 Environment files are initialized repo-wide by `scripts/env-init.sh`. Once that script has been run, this service should already have the `.env` file it needs for local development.
 
-If the service needs Kafka locally, start the shared development dependencies from the repository root:
+If the service needs Kafka locally, start the shared development dependencies and initialize topics from the repository root:
 
 ```bash
-docker compose -f infra/docker-compose.yml up -d kafka schema-registry
+docker compose -f infra/docker-compose.yml up -d --build kafka kafka-init schema-registry
 ```
 
 ## Development Server

--- a/apps/ingestion-service/README.md
+++ b/apps/ingestion-service/README.md
@@ -1,0 +1,84 @@
+# Ingestion Service
+
+Spring Boot service responsible for collecting raw cloud provider usage and billing data and introducing it into the CloudSherpa pipeline.
+
+## Runtime
+
+- Java 21
+- Spring Boot 3.5
+- Maven Wrapper
+- Container port: `8080`
+- Docker Compose host port: `8081`
+
+## Local Setup
+
+```bash
+cd apps/ingestion-service
+chmod +x mvnw
+```
+
+Environment files are initialized repo-wide by `scripts/env-init.sh`. Once that script has been run, this service should already have the `.env` file it needs for local development.
+
+If the service needs Kafka locally, start the shared development dependencies from the repository root:
+
+```bash
+docker compose -f infra/docker-compose.yml up -d kafka schema-registry
+```
+
+## Development Server
+
+```bash
+./mvnw spring-boot:run
+```
+
+Spring Boot runs on port `8080` by default unless `SERVER_PORT` or application configuration overrides it.
+
+## Build and Production Run
+
+```bash
+./mvnw clean package
+java -jar target/*.jar
+```
+
+To skip tests during a local packaging pass:
+
+```bash
+./mvnw clean package -DskipTests
+```
+
+## Tests
+
+```bash
+./mvnw test
+```
+
+## Docker
+
+From the repository root:
+
+```bash
+docker compose -f infra/docker-compose.yml up --build ingestion-service
+```
+
+## Dev Dependencies
+
+Maven resolves development and test dependencies from `pom.xml`.
+
+Key development dependencies include:
+
+- Spring Boot test support: `spring-boot-starter-test`
+- Kafka test support: `spring-kafka-test`
+- Maven Wrapper files: `mvnw` and `.mvn/wrapper`
+
+Do not commit generated Maven output from `target/`.
+
+## Environment Configuration
+
+Local environment values should live in `.env`. Keep committed defaults and documentation in `.env.example`. Use `scripts/env-init.sh` to copy `.env.example` files into `.env` files across the repo.
+
+### Development
+
+- If `scripts/env-init.sh` has already been run, the local `.env` file should be in place.
+- Use `localhost:29092` for Kafka when the app runs on the host.
+- Use `kafka:9092` for Kafka when the app runs inside Docker Compose.
+- Keep provider sandbox credentials separate from production cloud credentials.

--- a/apps/intelligence-engine/README.md
+++ b/apps/intelligence-engine/README.md
@@ -1,0 +1,75 @@
+# Intelligence Engine
+
+Python/FastAPI service for forecasting, anomaly detection, and future ML-driven recommendations.
+
+## Runtime
+
+- Python 3.11
+- FastAPI
+- Uvicorn
+- Default local port: `8000`
+- Docker Compose host port: `8000`
+
+## Local Setup
+
+```bash
+cd apps/intelligence-engine
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+Environment files are initialized repo-wide by `scripts/env-init.sh`. Once that script has been run, services with `.env.example` files should already have the `.env` files they need for local development. Add `apps/intelligence-engine/.env.example` before relying on the script for this service.
+
+If the service needs Kafka locally, start the shared development dependencies from the repository root:
+
+```bash
+docker compose -f infra/docker-compose.yml up -d kafka schema-registry
+```
+
+## Development Server
+
+```bash
+uvicorn src.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+The API is available at `http://localhost:8000`.
+
+## Production Run
+
+```bash
+uvicorn src.main:app --host 0.0.0.0 --port 8000
+```
+## Docker
+
+From the repository root:
+
+```bash
+docker compose -f infra/docker-compose.yml up --build intelligence-engine
+```
+
+## Dev Dependencies
+
+Python dependencies are pinned in `requirements.txt`.
+
+Key development/runtime groups include:
+
+- API layer: `fastapi`, `uvicorn`, `pydantic`
+- ML and analytics: `tensorflow`, `numpy`, `pandas`, `scikit-learn`
+- Kafka integration: `confluent-kafka`
+- Persistence: `psycopg`, `sqlalchemy`
+- Environment loading: `python-dotenv`
+
+Keep virtual environments out of git. Use `.venv/` locally. The `.gitignore` enforces this.
+
+## Environment Configuration
+
+Local environment values should live in `.env`. Add a `.env.example` file when new required variables are introduced, then use `scripts/env-init.sh` to copy `.env.example` files into `.env` files across the repo.
+
+### Development
+
+- If `scripts/env-init.sh` has already been run and this service has a `.env.example`, the local `.env` file should be in place.
+- Use `localhost:29092` for Kafka when the app runs on the host.
+- Use `kafka:9092` for Kafka when the app runs inside Docker Compose.
+- Use reload mode only for local development.

--- a/apps/intelligence-engine/README.md
+++ b/apps/intelligence-engine/README.md
@@ -22,10 +22,10 @@ pip install -r requirements.txt
 
 Environment files are initialized repo-wide by `scripts/env-init.sh`. Once that script has been run, services with `.env.example` files should already have the `.env` files they need for local development. Add `apps/intelligence-engine/.env.example` before relying on the script for this service.
 
-If the service needs Kafka locally, start the shared development dependencies from the repository root:
+If the service needs Kafka locally, start the shared development dependencies and initialize topics from the repository root:
 
 ```bash
-docker compose -f infra/docker-compose.yml up -d kafka schema-registry
+docker compose -f infra/docker-compose.yml up -d --build kafka kafka-init schema-registry
 ```
 
 ## Development Server

--- a/apps/kafka-init/README.md
+++ b/apps/kafka-init/README.md
@@ -1,0 +1,57 @@
+# Kafka Init
+
+One-shot Python container that initializes CloudSherpa Kafka topics for the local Docker Compose stack.
+
+## Runtime
+
+- Python 3.11
+- `confluent-kafka`
+- Runs once, creates topics, then exits
+- No exposed HTTP port
+
+## Local Setup
+
+```bash
+cd apps/kafka-init
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+Environment files are initialized repo-wide by `scripts/env-init.sh`. Once that script has been run, this service should already have the `.env` file it needs for local development.
+
+## Run Against Docker Kafka
+
+Start Kafka first from the repository root:
+
+```bash
+docker compose -f infra/docker-compose.yml up -d kafka
+```
+
+Then run the init container:
+
+```bash
+docker compose -f infra/docker-compose.yml up --build kafka-init
+```
+
+The service exits successfully after creating configured topics. Existing topics are skipped.
+
+## Docker Compose
+
+In the full stack, `kafka-init` runs after `kafka` starts:
+
+```bash
+docker compose -f infra/docker-compose.yml up --build
+```
+
+## Environment Configuration
+
+Local environment values should live in `.env`. Keep committed defaults and documentation in `.env.example`. Use `scripts/env-init.sh` to copy `.env.example` files into `.env` files across the repo.
+
+### Development
+
+- If `scripts/env-init.sh` has already been run, the local `.env` file should be in place.
+- Use `KAFKA_BOOTSTRAP=kafka:9092` when running inside Docker Compose.
+- Use `KAFKA_BOOTSTRAP=localhost:29092` only when running the Python script directly on the host.
+

--- a/apps/normalization-service/README.md
+++ b/apps/normalization-service/README.md
@@ -1,0 +1,85 @@
+# Normalization Service
+
+Spring Boot service responsible for transforming raw ingested cloud data into normalized records for downstream analytics.
+
+## Runtime
+
+- Java 21
+- Spring Boot 3.5
+- Maven Wrapper
+- Container port: `8080`
+- Docker Compose host port: `8082`
+
+## Local Setup
+
+```bash
+cd apps/normalization-service
+chmod +x mvnw
+```
+
+Environment files are initialized repo-wide by `scripts/env-init.sh`. Once that script has been run, this service should already have the `.env` file it needs for local development.
+
+If the service needs Kafka locally, start the shared development dependencies from the repository root:
+
+```bash
+docker compose -f infra/docker-compose.yml up -d kafka schema-registry
+```
+
+## Development Server
+
+```bash
+./mvnw spring-boot:run
+```
+
+Spring Boot runs on port `8080` by default unless `SERVER_PORT` or application configuration overrides it.
+
+## Build and Production Run
+
+```bash
+./mvnw clean package
+java -jar target/*.jar
+```
+
+To skip tests during a local packaging pass:
+
+```bash
+./mvnw clean package -DskipTests
+```
+
+## Tests
+
+```bash
+./mvnw test
+```
+
+## Docker
+
+From the repository root:
+
+```bash
+docker compose -f infra/docker-compose.yml up --build normalization-service
+```
+
+## Dev Dependencies
+
+Maven resolves development and test dependencies from `pom.xml`.
+
+Key development dependencies include:
+
+- Spring Boot test support: `spring-boot-starter-test`
+- Kafka test support: `spring-kafka-test`
+- Maven Wrapper files: `mvnw` and `.mvn/wrapper`
+
+Do not commit generated Maven output from `target/`.
+
+## Environment Configuration
+
+Local environment values should live in `.env`. Keep committed defaults and documentation in `.env.example`. Use `scripts/env-init.sh` to copy `.env.example` files into `.env` files across the repo.
+
+### Development
+
+- If `scripts/env-init.sh` has already been run, the local `.env` file should be in place.
+- Use `localhost:29092` for Kafka when the app runs on the host.
+- Use `kafka:9092` for Kafka when the app runs inside Docker Compose.
+- Keep schema or topic changes aligned with files under `libs/kafka/schemas`.
+

--- a/apps/normalization-service/README.md
+++ b/apps/normalization-service/README.md
@@ -19,10 +19,10 @@ chmod +x mvnw
 
 Environment files are initialized repo-wide by `scripts/env-init.sh`. Once that script has been run, this service should already have the `.env` file it needs for local development.
 
-If the service needs Kafka locally, start the shared development dependencies from the repository root:
+If the service needs Kafka locally, start the shared development dependencies and initialize topics from the repository root:
 
 ```bash
-docker compose -f infra/docker-compose.yml up -d kafka schema-registry
+docker compose -f infra/docker-compose.yml up -d --build kafka kafka-init schema-registry
 ```
 
 ## Development Server
@@ -82,4 +82,3 @@ Local environment values should live in `.env`. Keep committed defaults and docu
 - Use `localhost:29092` for Kafka when the app runs on the host.
 - Use `kafka:9092` for Kafka when the app runs inside Docker Compose.
 - Keep schema or topic changes aligned with files under `libs/kafka/schemas`.
-

--- a/docs/dev/CheatSheet.md
+++ b/docs/dev/CheatSheet.md
@@ -1,1 +1,231 @@
-# Hitchhikers guide to the CloudSherpa Repo
+# CloudSherpa Cheat Sheet
+
+Quick commands for day-to-day development. Run commands from the repository root unless a section says otherwise.
+
+## First-Time Setup
+
+Initialize local `.env` files:
+
+```bash
+cd scripts
+chmod +x env-init.sh
+./env-init.sh
+cd ..
+```
+
+Once `env-init.sh` has been run, the repo should have the local `.env` files needed by app and Docker Compose commands. The script is idempotent and skips `.env` files that already exist.
+
+Install app dependencies as needed:
+
+```bash
+cd apps/dashboard-frontend && npm install
+cd ../dashboard-backend && npm install
+cd ../alert-engine && npm install
+```
+
+For Python:
+
+```bash
+cd apps/intelligence-engine
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+Spring Boot services use their Maven wrappers:
+
+```bash
+chmod +x apps/ingestion-service/mvnw
+chmod +x apps/normalization-service/mvnw
+chmod +x apps/analytics-engine/mvnw
+```
+
+## Docker Compose
+
+Start Kafka and Schema Registry only:
+
+```bash
+docker compose -f infra/docker-compose.yml up -d kafka schema-registry
+```
+
+Start the full local stack:
+
+```bash
+docker compose -f infra/docker-compose.yml up --build
+```
+
+Start one service:
+
+```bash
+docker compose -f infra/docker-compose.yml up --build dashboard-frontend
+```
+
+Stop the stack:
+
+```bash
+docker compose -f infra/docker-compose.yml down
+```
+
+Follow logs:
+
+```bash
+docker compose -f infra/docker-compose.yml logs -f
+docker compose -f infra/docker-compose.yml logs -f kafka
+```
+
+Check container status:
+
+```bash
+docker compose -f infra/docker-compose.yml ps
+```
+
+## Local Dev Servers
+
+### Dashboard Frontend
+
+```bash
+cd apps/dashboard-frontend
+npm run dev
+```
+
+URL: `http://localhost:3000`
+
+### Dashboard Backend
+
+```bash
+cd apps/dashboard-backend
+npm run start:dev
+```
+
+URL: `http://localhost:3001`
+
+### Alert Engine
+
+```bash
+cd apps/alert-engine
+npm run dev
+```
+
+URL: `http://localhost:3000` locally, or `http://localhost:3002` through Docker Compose.
+
+### Intelligence Engine
+
+```bash
+cd apps/intelligence-engine
+source .venv/bin/activate
+uvicorn src.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+URL: `http://localhost:8000`
+
+### Ingestion Service
+
+```bash
+cd apps/ingestion-service
+./mvnw spring-boot:run
+```
+
+URL: `http://localhost:8080` locally, or `http://localhost:8081` through Docker Compose.
+
+### Normalization Service
+
+```bash
+cd apps/normalization-service
+./mvnw spring-boot:run
+```
+
+URL: `http://localhost:8080` locally, or `http://localhost:8082` through Docker Compose.
+
+### Analytics Engine
+
+```bash
+cd apps/analytics-engine
+./mvnw spring-boot:run
+```
+
+URL: `http://localhost:8080` locally, or `http://localhost:8083` through Docker Compose.
+
+## Build Commands
+
+```bash
+cd apps/dashboard-frontend && npm run build
+cd apps/dashboard-backend && npm run build
+cd apps/alert-engine && npm run build
+cd apps/ingestion-service && ./mvnw clean package
+cd apps/normalization-service && ./mvnw clean package
+cd apps/analytics-engine && ./mvnw clean package
+```
+
+For Spring Boot builds without tests:
+
+```bash
+./mvnw clean package -DskipTests
+```
+
+## Test Commands
+
+```bash
+cd apps/dashboard-backend && npm test
+cd apps/dashboard-backend && npm run test:e2e
+cd apps/alert-engine && npm test
+cd apps/ingestion-service && ./mvnw test
+cd apps/normalization-service && ./mvnw test
+cd apps/analytics-engine && ./mvnw test
+```
+
+## Lint and Format
+
+```bash
+cd apps/dashboard-frontend && npm run lint
+cd apps/dashboard-backend && npm run lint
+cd apps/dashboard-backend && npm run format
+```
+
+## Ports
+
+| Service | Local Dev Port | Docker Compose Host Port |
+| --- | ---: | ---: |
+| Dashboard Frontend | `3000` | `3000` |
+| Dashboard Backend | `3001` | `3001` |
+| Alert Engine | `3000` | `3002` |
+| Intelligence Engine | `8000` | `8000` |
+| Ingestion Service | `8080` | `8081` |
+| Normalization Service | `8080` | `8082` |
+| Analytics Engine | `8080` | `8083` |
+| Schema Registry | n/a | `9000` |
+| Kafka | n/a | `29092` |
+
+## Kafka Addresses
+
+- Host machine clients: `localhost:29092`
+- Docker Compose clients: `kafka:9092`
+- Host Schema Registry: `http://localhost:9000`
+- Docker Compose Schema Registry: `http://schema-registry:8081`
+
+## Useful Paths
+
+| Path | Purpose |
+| --- | --- |
+| `apps/` | Runtime services |
+| `infra/docker-compose.yml` | Local container stack |
+| `libs/kafka/` | Shared Kafka schemas |
+| `scripts/env-init.sh` | Initializes local `.env` files |
+| `docs/dev/MonorepoMadness.md` | Repo structure guide |
+| `docs/dev/UsingKafka.md` | Kafka usage notes |
+
+## Troubleshooting
+
+Rebuild one Docker image without cache:
+
+```bash
+docker compose -f infra/docker-compose.yml build --no-cache dashboard-backend
+```
+
+Remove containers and anonymous volumes:
+
+```bash
+docker compose -f infra/docker-compose.yml down -v
+```
+
+If Kafka connections fail, check whether the client is running on the host or inside Docker Compose and use the matching Kafka address.

--- a/docs/dev/CheatSheet.md
+++ b/docs/dev/CheatSheet.md
@@ -43,10 +43,10 @@ chmod +x apps/analytics-engine/mvnw
 
 ## Docker Compose
 
-Start Kafka and Schema Registry only:
+Start Kafka, initialize topics, and start Schema Registry:
 
 ```bash
-docker compose -f infra/docker-compose.yml up -d kafka schema-registry
+docker compose -f infra/docker-compose.yml up -d --build kafka kafka-init schema-registry
 ```
 
 Start the full local stack:
@@ -190,6 +190,7 @@ cd apps/dashboard-backend && npm run format
 | Dashboard Backend | `3001` | `3001` |
 | Alert Engine | `3000` | `3002` |
 | Intelligence Engine | `8000` | `8000` |
+| Kafka Init | n/a | n/a |
 | Ingestion Service | `8080` | `8081` |
 | Normalization Service | `8080` | `8082` |
 | Analytics Engine | `8080` | `8083` |
@@ -210,6 +211,7 @@ cd apps/dashboard-backend && npm run format
 | `apps/` | Runtime services |
 | `infra/docker-compose.yml` | Local container stack |
 | `libs/kafka/` | Shared Kafka schemas |
+| `apps/kafka-init/` | Local Kafka topic initialization service |
 | `scripts/env-init.sh` | Initializes local `.env` files |
 | `docs/dev/MonorepoMadness.md` | Repo structure guide |
 | `docs/dev/UsingKafka.md` | Kafka usage notes |

--- a/docs/dev/MonorepoMadness.md
+++ b/docs/dev/MonorepoMadness.md
@@ -1,1 +1,220 @@
 # Monorepo Madness
+
+This document explains where things live in the CloudSherpa repository and where new files should go. It is intentionally focused on directory. For service-specific setup, commands, ports, dependencies, and environment details, use the service READMEs under `apps/`.
+
+## Repository Tree
+
+_Generated on 26/04_. Should update regularly or automate via local git lifecycle hooks or github actions.
+
+```text
+.
+|-- .env.example
+|-- .gitignore
+|-- README.md
+|-- apps
+|   |-- alert-engine
+|   |-- analytics-engine
+|   |-- dashboard-backend
+|   |-- dashboard-frontend
+|   |-- ingestion-service
+|   |-- intelligence-engine
+|   `-- normalization-service
+|-- docs
+|   |-- assets
+|   |   `-- team-photos
+|   |       |-- TeamLogo.png
+|   |       `-- TeamPhoto.png
+|   `-- dev
+|       |-- CheatSheet.md
+|       |-- MonorepoMadness.md
+|       `-- UsingKafka.md
+|-- infra
+|   |-- README.md
+|   `-- docker-compose.yml
+|-- libs
+|   `-- kafka
+|       `-- example_schema.avsc
+`-- scripts
+    |-- README.md
+    |-- dev-dependencies.sh
+    |-- env-init.sh
+    `-- spring-init.sh
+```
+
+## Top-Level Directories
+
+| Path | Purpose |
+| --- | --- |
+| `apps/` | Independently runnable services. Each service owns its own source code, dependencies, Dockerfile, environment example, and README. |
+| `docs/` | Project documentation and supporting assets. |
+| `infra/` | Infrastructure and orchestration files, currently centered on Docker Compose. |
+| `libs/` | Shared contracts and reusable files used across service boundaries. |
+| `scripts/` | Setup and maintenance scripts used by developers. |
+
+Keep root files minimal. If a file can reasonably live in one of the directories above, place it there instead of at the repository root.
+
+## `apps/`
+
+Each folder in `apps/` is a runtime unit that can be built, run, tested, and deployed separately.
+
+Use `apps/` for code that:
+
+- has its own process or server;
+- owns a clear system responsibility;
+- has its own dependency manifest;
+- has its own Dockerfile;
+- has its own `.env.example`;
+- communicates with other services through explicit interfaces such as HTTP or Kafka.
+
+Do not put shared utility code in `apps/` just because one service uses it first. If it becomes a cross-service contract or reusable module, move it under `libs/`.
+
+### Standard Service Shape
+
+```text
+service-name/
+|-- Dockerfile
+|-- .env.example
+|-- README.md
+|-- src/
+|-- tests/
+`-- package.json / pom.xml / requirements.txt
+```
+
+Not every service will have every folder on day one, but new services should follow this shape as they grow.
+
+### Service Index
+
+Use these READMEs for service-specific setup, development commands, build commands, ports, dev dependencies, and environment guidance.
+
+| Service | README |
+| --- | --- |
+| Alert Engine | [`apps/alert-engine/README.md`](../../apps/alert-engine/README.md) |
+| Analytics Engine | [`apps/analytics-engine/README.md`](../../apps/analytics-engine/README.md) |
+| Dashboard Backend | [`apps/dashboard-backend/README.md`](../../apps/dashboard-backend/README.md) |
+| Dashboard Frontend | [`apps/dashboard-frontend/README.md`](../../apps/dashboard-frontend/README.md) |
+| Ingestion Service | [`apps/ingestion-service/README.md`](../../apps/ingestion-service/README.md) |
+| Intelligence Engine | [`apps/intelligence-engine/README.md`](../../apps/intelligence-engine/README.md) |
+| Normalization Service | [`apps/normalization-service/README.md`](../../apps/normalization-service/README.md) |
+
+## `docs/`
+
+Documentation belongs under `docs/`.
+
+Use:
+
+- `docs/dev/` for developer-facing guides;
+- `docs/assets/` for images, diagrams, screenshots, PDFs, and other static documentation assets.
+
+Current developer docs:
+
+| File | Purpose |
+| --- | --- |
+| [`docs/dev/CheatSheet.md`](CheatSheet.md) | Quick command reference for local development. |
+| [`docs/dev/MonorepoMadness.md`](MonorepoMadness.md) | Repository structure and file placement guide. |
+| [`docs/dev/UsingKafka.md`](UsingKafka.md) | Kafka-specific development notes. |
+
+## `infra/`
+
+Infrastructure files live in `infra/`.
+
+Current files:
+
+| File | Purpose |
+| --- | --- |
+| [`infra/docker-compose.yml`](../../infra/docker-compose.yml) | Local container stack for Kafka, Schema Registry, and app services. |
+| [`infra/README.md`](../../infra/README.md) | Infrastructure commands, ports, environment notes, and Docker Compose usage. |
+
+Put container orchestration, local infrastructure wiring, and future deployment-adjacent configuration here. Do not put application source code in `infra/`.
+
+## `libs/`
+
+Shared cross-service contracts and reusable files belong in `libs/`.
+
+Use `libs/` for:
+
+- Kafka schemas;
+- shared message contracts;
+- shared validation rules;
+- generated or shared types used by more than one service;
+- cross-service utilities that are not owned by a single app.
+
+Do not use `libs/` for service-specific business logic. If only one service uses it and owns it, keep it inside that service.
+
+### `libs/kafka/`
+
+Kafka-related shared definitions live under `libs/kafka/`.
+
+Current files:
+
+| File | Purpose |
+| --- | --- |
+| [`libs/kafka/example_schema.avsc`](../../libs/kafka/example_schema.avsc) | Example Avro schema for shared Kafka message contracts. |
+
+Schema changes should be coordinated with every producer and consumer that uses the schema.
+
+## `scripts/`
+
+Developer scripts belong in `scripts/`.
+
+Refer to [`scripts/README.md`](../../scripts/README.md) 
+
+Scripts should be repeatable where possible, documented in `scripts/README.md`, and scoped to setup or maintenance tasks that developers actually run more than once.
+
+## Root Files
+
+Root files should be limited to project-level entry points and configuration that genuinely applies to the whole repository.
+
+| File | Purpose |
+| --- | --- |
+| `README.md` | Main user-facing project overview and run instructions. |
+| `.env.example` | Repository-level environment template, if shared values are needed. |
+| `.gitignore` | Ignore rules for generated files, local secrets, dependencies, and build outputs. |
+
+## Environment Files
+
+Environment templates should live next to the code that consumes them.
+
+- Service-specific variables belong in `apps/<service>/.env.example`.
+- Shared repository-level variables may belong in root `.env.example`.
+- Real `.env` files are local and should not be committed.
+- Run `scripts/env-init.sh` once to create local `.env` files from existing `.env.example` files.
+
+Once `scripts/env-init.sh` has been run, local app and Docker Compose commands should have the expected `.env` files in place.
+
+## Adding Files
+
+Use this quick placement guide:
+
+| If you are adding... | Put it in... |
+| --- | --- |
+| A new independently runnable service | `apps/<service-name>/` |
+| Service-specific source code | `apps/<service-name>/src/` |
+| Service-specific tests | `apps/<service-name>/tests/` or the framework's test folder |
+| Service-specific setup docs | `apps/<service-name>/README.md` |
+| Docker Compose or local stack wiring | `infra/` |
+| Shared Kafka schemas | `libs/kafka/` |
+| Shared cross-service code or contracts | `libs/` |
+| Developer docs | `docs/dev/` |
+| Documentation images or diagrams | `docs/assets/` |
+| Repeatable setup scripts | `scripts/` |
+
+## Adding a New Service
+
+When adding a new service:
+
+1. Create `apps/<service-name>/`.
+2. Add source code, dependency manifest, Dockerfile, `.env.example`, and README.
+3. Document service-specific commands in the service README.
+4. Add the service to `infra/docker-compose.yml` if it should run in the local stack.
+5. Add the service to the service index in this document.
+6. Add quick commands to `docs/dev/CheatSheet.md` if developers need them often.
+
+Keep detailed service behavior out of this document. The service README is the source of truth for that service.
+
+## Related Docs
+
+- [`README.md`](../../README.md) - user-facing project overview and basic run instructions.
+- [`docs/dev/CheatSheet.md`](CheatSheet.md) - quick command reference.
+- [`infra/README.md`](../../infra/README.md) - Docker Compose and infrastructure details.
+- [`scripts/README.md`](../../scripts/README.md) - script usage.
+- [`docs/dev/UsingKafka.md`](UsingKafka.md) - Kafka development notes.

--- a/docs/dev/MonorepoMadness.md
+++ b/docs/dev/MonorepoMadness.md
@@ -18,6 +18,7 @@ _Generated on 26/04_. Should update regularly or automate via local git lifecycl
 |   |-- dashboard-frontend
 |   |-- ingestion-service
 |   |-- intelligence-engine
+|   |-- kafka-init
 |   `-- normalization-service
 |-- docs
 |   |-- assets
@@ -94,6 +95,7 @@ Use these READMEs for service-specific setup, development commands, build comman
 | Dashboard Frontend | [`apps/dashboard-frontend/README.md`](../../apps/dashboard-frontend/README.md) |
 | Ingestion Service | [`apps/ingestion-service/README.md`](../../apps/ingestion-service/README.md) |
 | Intelligence Engine | [`apps/intelligence-engine/README.md`](../../apps/intelligence-engine/README.md) |
+| Kafka Init | [`apps/kafka-init/README.md`](../../apps/kafka-init/README.md) |
 | Normalization Service | [`apps/normalization-service/README.md`](../../apps/normalization-service/README.md) |
 
 ## `docs/`

--- a/infra/README.md
+++ b/infra/README.md
@@ -4,7 +4,7 @@ Local infrastructure and container orchestration for CloudSherpa.
 
 ## Contents
 
-- `docker-compose.yml` - local Docker Compose stack for Kafka, Schema Registry, and CloudSherpa app containers.
+- `docker-compose.yml` - local Docker Compose stack for Kafka, Kafka topic initialization, Schema Registry, and CloudSherpa app containers.
 
 ## Prerequisites
 
@@ -24,10 +24,10 @@ The script is idempotent and does not overwrite existing `.env` files. Once it h
 
 ## Start Shared Dependencies
 
-Use this when running app dev servers directly on the host:
+Use this when running app dev servers directly on the host. This starts Kafka, runs `kafka-init` to create local topics, and starts Schema Registry:
 
 ```bash
-docker compose -f infra/docker-compose.yml up -d kafka schema-registry
+docker compose -f infra/docker-compose.yml up -d --build kafka kafka-init schema-registry
 ```
 
 Host connection values:
@@ -107,6 +107,7 @@ docker compose -f infra/docker-compose.yml logs -f kafka
 | `dashboard-backend` | `3001` | `3001` | NestJS API |
 | `alert-engine` | `3002` | `3000` | Express API |
 | `intelligence-engine` | `8000` | `8000` | FastAPI service |
+| `kafka-init` | n/a | n/a | One-shot Kafka topic initialization |
 | `ingestion-service` | `8081` | `8080` | Spring Boot service |
 | `normalization-service` | `8082` | `8080` | Spring Boot service |
 | `analytics-engine` | `8083` | `8080` | Spring Boot service |
@@ -121,6 +122,8 @@ The local Kafka container exposes two client paths:
 - `kafka:9092` for applications running inside Docker Compose.
 
 Use the correct address for the runtime location of the client. A service running in Docker Compose should not use `localhost:29092` to reach Kafka.
+
+`kafka-init` uses the Docker-network address by default and exits after creating configured topics. Re-running it is safe when topics already exist.
 
 ## Development vs Production
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,162 @@
+# Infrastructure
+
+Local infrastructure and container orchestration for CloudSherpa.
+
+## Contents
+
+- `docker-compose.yml` - local Docker Compose stack for Kafka, Schema Registry, and CloudSherpa app containers.
+
+## Prerequisites
+
+- Docker Engine
+- Docker Compose v2
+- App-level `.env` files initialized with `scripts/env-init.sh`
+
+Initialize environment files once before starting the stack:
+
+```bash
+cd scripts
+chmod +x env-init.sh
+./env-init.sh
+```
+
+The script is idempotent and does not overwrite existing `.env` files. Once it has been run, the Docker Compose stack should have the local `.env` files it needs. Services without a `.env.example` need one added before the script can initialize their `.env`.
+
+## Start Shared Dependencies
+
+Use this when running app dev servers directly on the host:
+
+```bash
+docker compose -f infra/docker-compose.yml up -d kafka schema-registry
+```
+
+Host connection values:
+
+- Kafka: `localhost:29092`
+- Schema Registry: `http://localhost:9000`
+
+Docker-network connection values:
+
+- Kafka: `kafka:9092`
+- Schema Registry: `http://schema-registry:8081`
+
+## Start the Full Stack
+
+From the repository root:
+
+```bash
+docker compose -f infra/docker-compose.yml up --build
+```
+
+Run in the background:
+
+```bash
+docker compose -f infra/docker-compose.yml up -d --build
+```
+
+## Start One Service
+
+```bash
+docker compose -f infra/docker-compose.yml up --build dashboard-frontend
+```
+
+Replace `dashboard-frontend` with any service name from the compose file.
+
+## Start Selected Services
+
+```bash
+docker compose -f infra/docker-compose.yml up --build dashboard-frontend dashboard-backend
+```
+
+Replace `dashboard-frontend` and `dashboard-backend` with any service name from the compose file.
+
+
+## Stop the Stack
+
+```bash
+docker compose -f infra/docker-compose.yml down
+```
+
+Stop and remove anonymous volumes:
+
+```bash
+docker compose -f infra/docker-compose.yml down -v
+```
+
+## Logs
+
+The following commands assume that containers are running.
+
+Follow all logs:
+
+```bash
+docker compose -f infra/docker-compose.yml logs -f
+```
+
+Follow one service:
+
+```bash
+docker compose -f infra/docker-compose.yml logs -f kafka
+```
+
+## Service Ports
+
+| Service | Host Port | Container Port | Notes |
+| --- | ---: | ---: | --- |
+| `dashboard-frontend` | `3000` | `3000` | Next.js frontend |
+| `dashboard-backend` | `3001` | `3001` | NestJS API |
+| `alert-engine` | `3002` | `3000` | Express API |
+| `intelligence-engine` | `8000` | `8000` | FastAPI service |
+| `ingestion-service` | `8081` | `8080` | Spring Boot service |
+| `normalization-service` | `8082` | `8080` | Spring Boot service |
+| `analytics-engine` | `8083` | `8080` | Spring Boot service |
+| `schema-registry` | `9000` | `8081` | Confluent Schema Registry |
+| `kafka` | `29092` | `29092` | External listener for host clients |
+
+## Kafka Listener Model
+
+The local Kafka container exposes two client paths:
+
+- `localhost:29092` for applications running on the host.
+- `kafka:9092` for applications running inside Docker Compose.
+
+Use the correct address for the runtime location of the client. A service running in Docker Compose should not use `localhost:29092` to reach Kafka.
+
+## Development vs Production
+
+### Development
+
+- Uses single-node Kafka in KRaft mode.
+- Uses plaintext Kafka listeners.
+- Uses local `.env` files under each app directory.
+- Builds app images from local source.
+- Intended for local integration testing, not production reliability.
+
+### Production
+(Planned, not yet implemented)
+- Use managed or hardened Kafka with authentication, TLS, backups, and monitoring.
+- Inject secrets through the deployment platform or a secret manager.
+- Do not mount local `.env` files into production containers.
+- Build immutable images through CI.
+- Pin deployment image tags instead of relying on `latest`.
+- Add health checks, resource limits, restart policies, and observability before production deployment.
+
+## Troubleshooting
+
+Check running containers:
+
+```bash
+docker compose -f infra/docker-compose.yml ps
+```
+
+Rebuild a service after dependency changes:
+
+```bash
+docker compose -f infra/docker-compose.yml build --no-cache dashboard-backend
+```
+
+Remove stopped containers and networks for this stack:
+
+```bash
+docker compose -f infra/docker-compose.yml down
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,3 +7,15 @@ This directory contains scripts intended for configuring the repo, installing de
 | **env-init.sh**      | Recursively finds and safely copies `.env.example` files to `.env` files. Each service depends on its own isolated environment variables as far as possible. Shared environment variables are configured in the root `.env`. Script behaviour and usage is further documented via comments made in the file itself. |
 | **spring-init.sh**      | Script used to for initializing services that uses Spring Boot framework, namely the `analytics-engine`, `ingestion-service` and `normalization-service`. This script is not meant for repeated runs. It just captures configuration in a structured format that can be reused for additional Spring Boot services. |
 | **dev-dependencies.sh**      | Work in progress. **DO NOT EXECUTE**|
+
+## Environment Initialization
+
+Run this once from the `scripts/` directory to copy every `.env.example` file to a matching `.env` file:
+
+```bash
+cd scripts
+chmod +x env-init.sh
+./env-init.sh
+```
+
+The script is idempotent and skips `.env` files that already exist. Once it has been run, local app and Docker Compose commands should have the expected `.env` files in place.


### PR DESCRIPTION
Closes #114 

### About the diff and PR constraints
The diff is very large I know, however I was very sure to change only documentation. The documentation also accurately reflects the current state of the repo. Many things are not optimized or user friendly, for example the `env-init.sh` script needs to be run from the `scripts` directory, this should change such that all scripts are runnable from the root directory (Issue https://github.com/COS301-SE-2026/CloudSherpa/issues/129), but I did not make any business logic changes in this PR. Very strictly only documentation was touched.

### Where should you start?

1. `docs/dev/MonorepoMadness.md` to understand the directory structure
2. `docs/dev/CheetSheet.md` for quick overview and initial repo setup
3. `infra/README.md` for an overview of the local container orchestration
4. `apps/<service>/README.md` for an overview on how to start developing each service.