### PR TITLE
Analytics db setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,0 @@
-POSTGRES_DB=analytics
-POSTGRES_USER=cloudsherpa
-POSTGRES_PASSWORD=mock_pass

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+POSTGRES_DB=analytics
+POSTGRES_USER=cloudsherpa
+POSTGRES_PASSWORD=mock_pass

--- a/docs/dev/CheatSheet.md
+++ b/docs/dev/CheatSheet.md
@@ -52,20 +52,13 @@ docker compose -f infra/docker-compose.yml up -d --build kafka kafka-init schema
 Start AnalyticsDB (TimescaleDB):
 
 ```bash
-docker compose --env-file .env -f infra/docker-compose.yml up -d analytics-db
+docker compose -f infra/docker-compose.yml up -d analytics-db
 ```
 
 Connect to AnalyticsDB:
 
 ```bash
 docker exec -it analytics-db sh -lc 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"'
-```
-
-Enable Timescale (one-time per database):
-
-```sql
-CREATE EXTENSION IF NOT EXISTS timescaledb;
-\dx
 ```
 
 Start the full local stack:

--- a/docs/dev/CheatSheet.md
+++ b/docs/dev/CheatSheet.md
@@ -49,6 +49,25 @@ Start Kafka, initialize topics, and start Schema Registry:
 docker compose -f infra/docker-compose.yml up -d --build kafka kafka-init schema-registry
 ```
 
+Start AnalyticsDB (TimescaleDB):
+
+```bash
+docker compose --env-file .env -f infra/docker-compose.yml up -d analytics-db
+```
+
+Connect to AnalyticsDB:
+
+```bash
+docker exec -it analytics-db sh -lc 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"'
+```
+
+Enable Timescale (one-time per database):
+
+```sql
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+\dx
+```
+
 Start the full local stack:
 
 ```bash

--- a/infra/README.md
+++ b/infra/README.md
@@ -40,6 +40,59 @@ Docker-network connection values:
 - Kafka: `kafka:9092`
 - Schema Registry: `http://schema-registry:8081`
 
+## AnalyticsDB (TimescaleDB)
+
+CloudSherpa’s AnalyticsDB runs as a dedicated TimescaleDB container named `analytics-db`. The `analytics-engine` container can reach it over the Docker network.
+
+### Before you start
+
+1. Make sure you have a repo-root `.env` file. It should define:
+
+   - `ANALYTICS_DB_NAME`
+   - `ANALYTICS_DB_USER`
+   - `ANALYTICS_DB_PASSWORD`
+2. Run the commands below from the repository root.
+
+### Start AnalyticsDB
+
+1. Start the database (first time will download the TimescaleDB image):
+
+   ```bash
+   docker compose --env-file .env -f infra/docker-compose.yml pull analytics-db
+   docker compose --env-file .env -f infra/docker-compose.yml up -d analytics-db
+   docker compose --env-file .env -f infra/docker-compose.yml ps
+   ```
+
+2. Open `psql` inside the DB container:
+
+   ```bash
+   docker exec -it analytics-db sh -lc 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"'
+   ```
+
+3. Enable TimescaleDB (one-time per database):
+
+   ```sql
+   CREATE EXTENSION IF NOT EXISTS timescaledb;
+   \dx
+   ```
+
+4. Start creating schemas/tables as normal. Exit `psql` with `\q`.
+
+### Container-to-container connectivity
+
+- From containers in this Compose stack: use `analytics-db:5432`
+- From the host machine (because the port is published): use `localhost:5432`
+
+### Persistence and resets
+
+AnalyticsDB data is persisted via a named Docker volume (so data survives container restarts).
+
+To reset the stack and remove volumes (destructive; deletes DB data):
+
+```bash
+docker compose --env-file .env -f infra/docker-compose.yml down -v
+```
+
 ## Start the Full Stack
 
 From the repository root:

--- a/infra/README.md
+++ b/infra/README.md
@@ -48,35 +48,37 @@ CloudSherpa’s AnalyticsDB runs as a dedicated TimescaleDB container named `ana
 
 1. Make sure you have a repo-root `.env` file. It should define:
 
-   - `ANALYTICS_DB_NAME`
-   - `ANALYTICS_DB_USER`
-   - `ANALYTICS_DB_PASSWORD`
+   - `POSTGRES_DB`
+   - `POSTGRES_USER`
+   - `POSTGRES_PASSWORD`
 2. Run the commands below from the repository root.
 
 ### Start AnalyticsDB
 
-1. Start the database (first time will download the TimescaleDB image):
+1. Start the database:
 
    ```bash
-   docker compose --env-file .env -f infra/docker-compose.yml pull analytics-db
-   docker compose --env-file .env -f infra/docker-compose.yml up -d analytics-db
-   docker compose --env-file .env -f infra/docker-compose.yml ps
+   docker compose -f infra/docker-compose.yml up -d analytics-db
+   docker compose -f infra/docker-compose.yml ps
    ```
 
-2. Open `psql` inside the DB container:
+   On first startup, initialization scripts automatically run:
+   - TimescaleDB extension is enabled
+   - Base schemas and tables are created via `persistence/analytics/analytics-schema.sql`
+
+2. Connect to the database if needed:
 
    ```bash
    docker exec -it analytics-db sh -lc 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"'
    ```
 
-3. Enable TimescaleDB (one-time per database):
+   You can run additional SQL commands here. Exit `psql` with `\q`.
 
-   ```sql
-   CREATE EXTENSION IF NOT EXISTS timescaledb;
-   \dx
-   ```
+**Note:** Init scripts under `persistence/analytics/` run only on first startup with a fresh volume. If you started the DB before this automation was added (or you need to re-run init scripts), reset the DB volume:
 
-4. Start creating schemas/tables as normal. Exit `psql` with `\q`.
+```bash
+docker compose -f infra/docker-compose.yml down -v
+```
 
 ### Container-to-container connectivity
 
@@ -90,7 +92,7 @@ AnalyticsDB data is persisted via a named Docker volume (so data survives contai
 To reset the stack and remove volumes (destructive; deletes DB data):
 
 ```bash
-docker compose --env-file .env -f infra/docker-compose.yml down -v
+docker compose -f infra/docker-compose.yml down -v
 ```
 
 ## Start the Full Stack

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -130,3 +130,25 @@ services:
     container_name: intelligence-engine
     env_file:
       - ../apps/intelligence-engine/.env
+
+  analytics-db:
+    image: timescale/timescaledb:2.16.1-pg16
+    container_name: analytics-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${ANALYTICS_DB_NAME:-analytics}
+      POSTGRES_USER: ${ANALYTICS_DB_USER:-cloudsherpa}
+      POSTGRES_PASSWORD: ${ANALYTICS_DB_PASSWORD}
+    ports:
+      - "5432:5432"
+    volumes:
+      - analytics_db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+volumes:
+  analytics_db_data: 
+  # Ensures that the data is persistent across docker compose down / up 

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -135,14 +135,13 @@ services:
     image: timescale/timescaledb:2.16.1-pg16
     container_name: analytics-db
     restart: unless-stopped
-    environment:
-      POSTGRES_DB: ${ANALYTICS_DB_NAME:-analytics}
-      POSTGRES_USER: ${ANALYTICS_DB_USER:-cloudsherpa}
-      POSTGRES_PASSWORD: ${ANALYTICS_DB_PASSWORD}
+    env_file:
+      - ../.env
     ports:
       - "5432:5432"
     volumes:
       - analytics_db_data:/var/lib/postgresql/data
+      - ../persistence/analytics:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 5s

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -136,7 +136,7 @@ services:
     container_name: analytics-db
     restart: unless-stopped
     env_file:
-      - ../.env
+      - ../persistence/analytics/.env
     ports:
       - "5432:5432"
     volumes:

--- a/persistence/analytics/.env.example
+++ b/persistence/analytics/.env.example
@@ -1,0 +1,3 @@
+POSTGRES_DB=analytics
+POSTGRES_USER=cloudsherpa
+POSTGRES_PASSWORD=mock_pass

--- a/persistence/analytics/analytics-schema.sql
+++ b/persistence/analytics/analytics-schema.sql
@@ -1,0 +1,3 @@
+-- AnalyticsDB init script
+
+CREATE EXTENSION IF NOT EXISTS timescaledb;


### PR DESCRIPTION
This PR adds a local AnalyticsDB backed by TimescaleDB and documents the exact steps to start it, connect to it, and enable the Timescale extension for development.

Added a new Docker Compose service analytics-db, published on localhost:5432.

Primary step-by-step guide: **README.md**
Quick commands: **CheatSheet.md**