### PR TITLE
Mkdocs setup and CD

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,66 @@
+# This action publishes mkdocs to CloudSherpa GitHub pages on push to dev or main. 
+name: Publish Docs
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  # Workflow dispatch adds "run workflow" button in actions tab, if we want to manually rerun it for
+  # docs on main for example
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# If doc deployment in progress, cancel
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build MkDocs site
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install MkDocs dependencies
+        run: |
+          pip install mkdocs mkdocs-material pymdown-extensions
+
+      - name: Build MkDocs site
+        # Strict fails on warnings, make sure all links can resolve otherwise action fail
+        run: |
+          mkdocs build --strict
+
+      # Previous steps generates site/ directory with built docs, this uploads as artifacts for 
+      # deploy step to use
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: site
+
+  deploy:
+    # Standard pages deployment
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/api/api-placeholder.md
+++ b/docs/api/api-placeholder.md
@@ -1,0 +1,1 @@
+# Link To Services Swagger Docs to be Added Here

--- a/docs/dev/MonorepoMadness.md
+++ b/docs/dev/MonorepoMadness.md
@@ -90,14 +90,14 @@ Use these READMEs for service-specific setup, development commands, build comman
 
 | Service | README |
 | --- | --- |
-| Alert Engine | [`apps/alert-engine/README.md`](../../apps/alert-engine/README.md) |
-| Analytics Engine | [`apps/analytics-engine/README.md`](../../apps/analytics-engine/README.md) |
-| Dashboard Backend | [`apps/dashboard-backend/README.md`](../../apps/dashboard-backend/README.md) |
-| Dashboard Frontend | [`apps/dashboard-frontend/README.md`](../../apps/dashboard-frontend/README.md) |
-| Ingestion Service | [`apps/ingestion-service/README.md`](../../apps/ingestion-service/README.md) |
-| Intelligence Engine | [`apps/intelligence-engine/README.md`](../../apps/intelligence-engine/README.md) |
-| Kafka Init | [`apps/kafka-init/README.md`](../../apps/kafka-init/README.md) |
-| Normalization Service | [`apps/normalization-service/README.md`](../../apps/normalization-service/README.md) |
+| Alert Engine | [`docs/services/alert-engine.md`](../services/alert-engine.md) |
+| Analytics Engine | [`docs/services/analytics-engine.md`](../services/analytics-engine.md) |
+| Dashboard Backend | [`docs/services/dashboard-backend.md`](../services/dashboard-backend.md) |
+| Dashboard Frontend | [`docs/services/dashboard-frontend.md`](../services/dashboard-frontend.md) |
+| Ingestion Service | [`docs/services/ingestion-service.md`](../services/ingestion-service.md) |
+| Intelligence Engine | [`docs/services/intelligence-engine.md`](../services/intelligence-engine.md) |
+| Kafka Init | [`docs/services/kafka-init.md`](../services/kafka-init.md) |
+| Normalization Service | [`docs/services/normalization-service.md`](../services/normalization-service.md) |
 
 ## `docs/`
 
@@ -124,8 +124,8 @@ Current files:
 
 | File | Purpose |
 | --- | --- |
-| [`infra/docker-compose.yml`](../../infra/docker-compose.yml) | Local container stack for Kafka, Schema Registry, and app services. |
-| [`infra/README.md`](../../infra/README.md) | Infrastructure commands, ports, environment notes, and Docker Compose usage. |
+| `infra/docker-compose.yml` | Local container stack for Kafka, Schema Registry, and app services. |
+| `infra/README.md` | Infrastructure commands, ports, environment notes, and Docker Compose usage. |
 
 Put container orchestration, local infrastructure wiring, and future deployment-adjacent configuration here. Do not put application source code in `infra/`.
 
@@ -151,7 +151,7 @@ Current files:
 
 | File | Purpose |
 | --- | --- |
-| [`libs/kafka/schemas/cloud_usage_event.avsc`](../../libs/kafka/schemas/cloud_usage_event.avsc) | Avro schema for cloud usage events. |
+| `libs/kafka/schemas/cloud_usage_event.avsc` | Avro schema for cloud usage events. |
 
 Treat `libs/kafka/schemas` as the canonical source if a service-local `src/main/avro` copy differs.
 
@@ -159,7 +159,7 @@ Treat `libs/kafka/schemas` as the canonical source if a service-local `src/main/
 
 Developer scripts belong in `scripts/`.
 
-Refer to [`scripts/README.md`](../../scripts/README.md) 
+Refer to `scripts/README.md`.
 
 Scripts should be repeatable where possible, documented in `scripts/README.md`, and scoped to setup or maintenance tasks that developers actually run more than once.
 
@@ -193,7 +193,7 @@ Use this quick placement guide:
 | A new independently runnable service | `apps/<service-name>/` |
 | Service-specific source code | `apps/<service-name>/src/` |
 | Service-specific tests | `apps/<service-name>/tests/` or the framework's test folder |
-| Service-specific setup docs | `apps/<service-name>/README.md` |
+| Service-specific setup docs | `docs/services/<service-name>.md` symlinked to `apps/<service-name>/README.md` |
 | Docker Compose or local stack wiring | `infra/` |
 | Shared Kafka schemas | `libs/kafka/schemas/` |
 | Shared cross-service code or contracts | `libs/` |
@@ -216,8 +216,8 @@ Keep detailed service behavior out of this document. The service README is the s
 
 ## Related Docs
 
-- [`README.md`](../../README.md) - user-facing project overview and basic run instructions.
+- `README.md` - user-facing project overview and basic run instructions.
 - [`docs/dev/CheatSheet.md`](CheatSheet.md) - quick command reference.
-- [`infra/README.md`](../../infra/README.md) - Docker Compose and infrastructure details.
-- [`scripts/README.md`](../../scripts/README.md) - script usage.
+- `infra/README.md` - Docker Compose and infrastructure details.
+- `scripts/README.md` - script usage.
 - [`docs/dev/UsingKafka.md`](UsingKafka.md) - Kafka development notes.

--- a/docs/doxygen/doxygen-placeholder.md
+++ b/docs/doxygen/doxygen-placeholder.md
@@ -1,0 +1,1 @@
+# Link to generated Doxygen site to be added here

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,25 @@
+# CloudSherpa Documentation
+
+Welcome to the CloudSherpa developer documentation.
+
+## Main sections
+
+??? note "Developer Guides"
+    [Developer Guides](dev/CheatSheet.md)
+
+    Core development resources, including workflows, conventions, and quick-reference material for working within CloudSherpa.
+
+??? note "Service Documentation"
+    [Service Documentation](services/alert-engine.md)
+
+    CloudSherpa follows a microservices architecture with event-driven communication. Each service is documented in detail, covering responsibilities and dependencies.
+
+??? note "REST API Documentation"
+    [REST API Documentation](api/api-placeholder.md)
+
+    Swagger (OpenAPI) provides interactive documentation for all REST endpoints exposed across services.
+
+??? note "Doxygen Code Reference"
+    [Doxygen Documentation](doxygen/doxygen-placeholder.md)
+
+    Inline code documentation is generated using Doxygen, providing detailed reference material for classes, functions, and internal logic.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,9 @@ Welcome to the CloudSherpa developer documentation.
 
 ## Main sections
 
+!!! warning
+    This documentation is intended as **development documentation**. It is automatically deployed on `push` to the `dev` and `main` branches of the _CloudSherpa_ repository. It is thus possible and highly likely that this documentation documents implementation done on the `dev` branch that **does not exist** on the `main` branch. For the current stage of _CloudSherpa_ development, this is intentional. It is still something to take note of and keep in mind as you are reading this documentation.
+
 ??? note "Developer Guides"
     [Developer Guides](dev/CheatSheet.md)
 

--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -1,0 +1,1 @@
+../../scripts/README.md

--- a/docs/services/alert-engine.md
+++ b/docs/services/alert-engine.md
@@ -1,0 +1,1 @@
+../../apps/alert-engine/README.md

--- a/docs/services/analytics-engine.md
+++ b/docs/services/analytics-engine.md
@@ -1,0 +1,1 @@
+../../apps/analytics-engine/README.md

--- a/docs/services/dashboard-backend.md
+++ b/docs/services/dashboard-backend.md
@@ -1,0 +1,1 @@
+../../apps/dashboard-backend/README.md

--- a/docs/services/dashboard-frontend.md
+++ b/docs/services/dashboard-frontend.md
@@ -1,0 +1,1 @@
+../../apps/dashboard-frontend/README.md

--- a/docs/services/ingestion-service.md
+++ b/docs/services/ingestion-service.md
@@ -1,0 +1,1 @@
+../../apps/ingestion-service/README.md

--- a/docs/services/intelligence-engine.md
+++ b/docs/services/intelligence-engine.md
@@ -1,0 +1,1 @@
+../../apps/intelligence-engine/README.md

--- a/docs/services/kafka-init.md
+++ b/docs/services/kafka-init.md
@@ -1,0 +1,1 @@
+../../apps/kafka-init/README.md

--- a/docs/services/normalization-service.md
+++ b/docs/services/normalization-service.md
@@ -1,0 +1,1 @@
+../../apps/normalization-service/README.md

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,42 @@
+[data-md-color-scheme="slate"] {
+
+  /* Primary (header, tabs, nav) */
+  --md-primary-fg-color: #0B3C5D;
+  --md-primary-fg-color--light: #145A86;
+  --md-primary-fg-color--dark: #072B40;
+
+  /* Accent (links, highlights) */
+  --md-accent-fg-color: #2ECC71;
+
+  /* Backgrounds */
+  --md-default-bg-color: #0F172A;        /* deep dark */
+  --md-default-fg-color: #E2E8F0;        /* main text */
+  --md-default-fg-color--light: #CBD5F5; /* secondary text */
+  --md-default-fg-color--lighter: #94A3B8;
+
+  /* Code blocks */
+  --md-code-bg-color: #020617;
+  --md-code-fg-color: #E2E8F0;
+
+  /* Links */
+  --md-typeset-a-color: #2ECC71;
+
+  /* Admonitions */
+  --md-admonition-bg-color: #1E293B;
+
+  /* Tables */
+  --md-typeset-table-color: #E2E8F0;
+
+  /* Borders / subtle UI */
+  --md-default-border-color: rgba(255, 255, 255, 0.1);
+
+  /* Increase logo size */
+    .md-header__button.md-logo img {
+        height: 55px; 
+        width: auto;
+        background-color: white;
+        border-radius: 20px;
+        padding: 5px;
+        margin-top: 5px;
+    }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,62 @@
+site_name: CloudSherpa Docs
+site_description: Developer documentation for the CloudSherpa monorepo
+repo_name: CloudSherpa
+docs_dir: docs
+site_dir: site
+
+theme:
+  name: material
+  logo: assets/team-photos/TeamLogo.png
+  palette:
+    - scheme: slate
+      primary: blue
+      accent: green
+
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+
+nav:
+  - Home: index.md
+
+  - Developer Guides:
+      - Cheat Sheet: dev/CheatSheet.md
+      - Monorepo Madness: dev/MonorepoMadness.md
+      - Using Kafka: dev/UsingKafka.md
+      - Development Scripts: scripts/README.md
+
+  - Services:
+      - Alert Engine: services/alert-engine.md
+      - Analytics Engine: services/analytics-engine.md
+      - Dashboard Backend: services/dashboard-backend.md
+      - Dashboard Frontend: services/dashboard-frontend.md
+      - Ingestion Service: services/ingestion-service.md
+      - Intelligence Engine: services/intelligence-engine.md
+      - Kafka Init: services/kafka-init.md
+      - Normalization Service: services/normalization-service.md
+  
+  - API Documentation:
+      - Placeholder: api/api-placeholder.md
+  
+  - Doxygen:
+      - Placeholder: doxygen/doxygen-placeholder.md
+
+extra_css:
+  - stylesheets/extra.css
+
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true
+  - tables
+  - fenced_code
+  - codehilite
+  - pymdownx.superfences
+  - pymdownx.details
+  - pymdownx.highlight
+  - pymdownx.inlinehilite

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,6 +7,7 @@ This directory contains scripts intended for configuring the repo, installing de
 | **env-init.sh**      | Recursively finds and safely copies `.env.example` files to `.env` files. Each service depends on its own isolated environment variables as far as possible. Shared environment variables are configured in the root `.env`. Script behaviour and usage is further documented via comments made in the file itself. |
 | **spring-init.sh**      | Script used to for initializing services that uses Spring Boot framework, namely the `analytics-engine`, `ingestion-service` and `normalization-service`. This script is not meant for repeated runs. It just captures configuration in a structured format that can be reused for additional Spring Boot services. |
 | **dev-dependencies.sh**      | Work in progress. **DO NOT EXECUTE**|
+| **mkdocs-local.sh**      | Creates Python venv, installs required mkdocs pip packages, serves mkdocs locally. Run from root directory. |
 
 ## Environment Initialization
 

--- a/scripts/mkdocs-local.sh
+++ b/scripts/mkdocs-local.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# USAGE
+# Run from root directory, ./scripts/mkdocs-local.sh
+
+if [[ ! -d "docs/.venv" ]]; then
+    echo "Creating Python docs venv..."
+    python3 -m venv docs/.venv
+fi
+
+source docs/.venv/bin/activate
+pip install mkdocs mkdocs-material pymdown-extensions
+
+mkdocs serve
+


### PR DESCRIPTION
Closes https://github.com/COS301-SE-2026/CloudSherpa/issues/139

### Serving docs locally
```sh
sudo chmod +x scripts/mkdocs-local.sh
./scripts/mkdocs-local.sh
```

### Symlinks
Mkdocs expects all `.md` files to be in dedicated `docs` directory. Added symlinks from all over the repo to the docs directory. Updated existing markdown links to refer to symlinked files. Please do a quick google search on symlinks if you have not encountered them yet. Basically everything changed in linked file will change in original and vice versa.  

### Deploying to pages
Added CD workflow to deploy docs to GH pages on push to dev and main. We will only know if it works once we merge so YOLO :beers:

### Overview
[Screencast from 2026-04-27 16-31-21.webm](https://github.com/user-attachments/assets/66992b2f-c2a9-42df-849f-3f3083cc9b18)
 
 ### To-do
 Doxygen and Swagger setup and deployment, will do in seperate branches and they will have their own PRs