### PR TITLE
Docs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,24 +43,14 @@ jobs:
         run: |
           mkdocs build --strict
 
-      # Previous steps generates site/ directory with built docs, this uploads as artifacts for 
-      # deploy step to use
-      - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v4
+      - name: Add nojekyll file
+        run: |
+          touch site/.nojekyll
+
+      - name: Deploy to gh-pages branch
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          path: site
-
-  deploy:
-    # Standard pages deployment
-    name: Deploy to GitHub Pages
-    runs-on: ubuntu-latest
-    needs: build
-
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
-      - name: Deploy GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          publish_branch: gh-pages
+          force_orphan: true


### PR DESCRIPTION
So the previous actions failed due to us being restricted as to what branches can publish to GH pages via actions (only `main` was allowed). Circumvented that by following a common pattern, creating a dedicated `gh-pages` branch. Had some issues with that with me being stupid as you saw but it is fixed now and docs are deployed. This PR fixes the action to not publish to pages directly, but build and then commit to `gh-pages` branch (only the documentation artifacts, i.e. everything in the `site` directory), which will then be redeployed. Let me know if we still want to do this, otherwise we can treat it as an experiment and revert. 