### PR TITLE
Analytics db tables

### DIFF
--- a/docs/persistence/analytics-db.md
+++ b/docs/persistence/analytics-db.md
@@ -1,0 +1,1 @@
+../../persistence/analytics/analytics-db.md

--- a/infra/README.md
+++ b/infra/README.md
@@ -57,7 +57,11 @@ CloudSherpa’s AnalyticsDB runs as a dedicated TimescaleDB container named `ana
 
 ### Start AnalyticsDB
 
-1. Start the database:
+1. **First time only:** Reset the volume to ensure init scripts run:
+   ```bash
+   docker compose -f infra/docker-compose.yml down -v
+
+2. Start the database:
 
    ```bash
    docker compose -f infra/docker-compose.yml up -d analytics-db
@@ -68,7 +72,8 @@ CloudSherpa’s AnalyticsDB runs as a dedicated TimescaleDB container named `ana
    - TimescaleDB extension is enabled
    - Base schemas and tables are created via `persistence/analytics/analytics-schema.sql`
 
-2. Connect to the database if needed:
+3. Connect to the database if needed:
+   Currently using `psql`: The command-line interface (CLI) client for PostgreSQL
 
    ```bash
    docker exec -it analytics-db sh -lc 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"'
@@ -76,11 +81,74 @@ CloudSherpa’s AnalyticsDB runs as a dedicated TimescaleDB container named `ana
 
    You can run additional SQL commands here. Exit `psql` with `\q`.
 
-**Note:** Init scripts under `persistence/analytics/` run only on first startup with a fresh volume. If you started the DB before this automation was added (or you need to re-run init scripts), reset the DB volume:
+4. Verify the schema was created successfully:
 
-```bash
-docker compose -f infra/docker-compose.yml down -v
-```
+   Inside psql, run these commands to verify:
+
+   **List all tables:**
+   ```sql
+   \dt
+   ```
+
+   Expected output:
+   ```
+                List of relations
+    Schema |        Name        | Type  |   Owner
+   --------+-----------------------+-------+----------
+    public | environment_reference | table | cloudsherpa
+    public | normalized_metrics    | table | cloudsherpa
+   (2 rows)
+   ```
+
+   **View the normalized_metrics table structure:**
+   ```sql
+   \d normalized_metrics
+   ```
+
+   Expected output:
+   ```
+                             Table "public.normalized_metrics"
+         Column      |           Type           | Collation | Nullable | Default
+   -------------------+--------------------------+-----------+----------+---------
+    recorded_at       | timestamp with time zone |           | not null |
+    environment_id    | uuid                     |           |          |
+    resource_id       | character varying(255)   |           | not null |
+    service_category  | character varying(100)   |           | not null |
+    usage_amount      | numeric                  |           | not null |
+    usage_unit        | character varying(50)    |           | not null |
+    cost_amount       | numeric                  |           | not null |
+    currency          | character varying(10)    |           |          | 'ZAR'::character varying
+   Indexes:
+       "ix_environment_time" btree (environment_id, recorded_at DESC)
+   ```
+
+   **Verify TimescaleDB hypertable:**
+   ```sql
+   SELECT * FROM timescaledb_information.hypertables;
+   ```
+
+   Expected output:
+   ```
+    hypertable_schema | hypertable_name    | owner
+   -------------------+--------------------+----------
+    public            | normalized_metrics | cloudsherpa
+   (1 row)
+   ```
+
+   **Check row count (should be empty initially):**
+   ```sql
+   SELECT COUNT(*) FROM normalized_metrics;
+   ```
+
+   Expected output:
+   ```
+    count
+   -------
+        0
+   (1 row)
+   ```
+
+   Exit psql with `\q`.
 
 ### Container-to-container connectivity
 

--- a/persistence/analytics/analytics-db.md
+++ b/persistence/analytics/analytics-db.md
@@ -1,0 +1,61 @@
+# AnalyticsDB Schema Documentation
+
+This database is powered by **TimescaleDB** (a time-series extension for PostgreSQL). It is specifically designed to ingest, store, and query massive amounts of standardized cloud billing data very quickly.
+
+## Tables
+
+### `environment_reference`
+
+A lookup table that acts as a registry for the connected cloud accounts. It provides the analytics engine with just enough context to group and compare costs across different cloud platforms.
+
+**Fields:**
+
+| Field | Type | Constraints | Purpose |
+|-------|------|-------------|---------|
+| `environment_id` | UUID | Primary Key | Unique system identifier for a connected cloud account. |
+| `provider` | VARCHAR(50) | NOT NULL | Standardized cloud provider name (e.g., `AWS`, `GCP`, `AZURE`). Enables easy calculation and comparison of spending across different clouds. |
+| `created_at` | TIMESTAMPTZ | DEFAULT NOW() | Timestamp when this environment was first registered. Useful for system auditing and debugging. |
+
+---
+
+### `normalized_metrics`
+
+Stores the standardized output from the **Normalizer** service. Takes the chaotic, varied billing formats from AWS, GCP, and Azure and unifies them into one standardized structure.
+
+**Fields:**
+
+| Field | Type | Constraints | Purpose |
+|-------|------|-------------|---------|
+| `recorded_at` | TIMESTAMPTZ | NOT NULL | The exact date/time the cost or usage occurred. TimescaleDB uses it to organize and retrieve data efficiently. |
+| `environment_id` | UUID | Foreign Key (`environment_reference`) | Links back to the cloud account. Answers: "Which cloud account incurred this cost?" |
+| `resource_id` | VARCHAR(255) | NOT NULL | Unique identifier from the cloud provider (e.g., AWS EC2 instance ID `i-0abcd1234`, GCP bucket name). Enables tracking costs down to individual resources. |
+| `service_category` | VARCHAR(100) | NOT NULL | CloudSherpa standardized service grouping (e.g., `Compute`, `Storage`, `Networking`). Allows cross-cloud aggregation regardless of provider-specific terminology. |
+| `usage_amount` | NUMERIC | NOT NULL | Raw volume of consumption (e.g., `730`, `50.5`). Tracks how much of a resource was used. |
+| `usage_unit` | VARCHAR(50) | NOT NULL | Unit of measurement (e.g., `vCPU-hours`, `GB-months`). Gives `usage_amount` real-world meaning. |
+| `cost_amount` | NUMERIC | NOT NULL | Actual money billed for this line item. Tracks financial spend. |
+| `currency` | VARCHAR(10) | DEFAULT 'ZAR' | Currency code for the cost. Defaults to South African Rand (ZAR). Ensures financial data is tracked accurately. |
+
+
+## Database Optimizations
+
+### Hypertable
+
+**SQL:**
+```sql
+SELECT create_hypertable('normalized_metrics', 'recorded_at');
+```
+
+**What it does:** Converts the standard `normalized_metrics` table into a **TimescaleDB Hypertable**, automatically partitioning it by time.
+
+**Why we need it:** This chops the massive table into smaller, time-based chunks. When the application queries data for "last week", the database doesn't scan years of history, it just grabs the specific chunks for last week, resulting in massive performance gains.
+
+### Composite Index
+
+**SQL:**
+```sql
+CREATE INDEX ix_environment_time ON normalized_metrics (environment_id, recorded_at DESC);
+```
+
+**What it does:** Creates an index organized first by account ID, then by time in descending order (newest first).
+
+**Why we need it:** When a user opens their dashboard, the system immediately queries for their account's most recent data. This index allows the database to instantly jump to exactly that subset of data without scanning the entire table.

--- a/persistence/analytics/analytics-schema.sql
+++ b/persistence/analytics/analytics-schema.sql
@@ -1,3 +1,31 @@
 -- AnalyticsDB init script
-
 CREATE EXTENSION IF NOT EXISTS timescaledb;
+
+-- Provides a valid foreign key target for the normalized_metrics table.
+-- Enables cross-cloud cost comparison by storing the 'provider' (AWS/GCP/AZURE).
+CREATE TABLE environment_reference (
+    environment_id UUID PRIMARY KEY,
+    provider VARCHAR(50) NOT NULL, -- 'AWS', 'GCP', or 'AZURE'
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- This stores the output of the Normalizer service
+CREATE TABLE normalized_metrics (
+    recorded_at TIMESTAMPTZ NOT NULL,
+    environment_id UUID REFERENCES environment_reference(environment_id),
+    resource_id VARCHAR(255) NOT NULL,
+    service_category VARCHAR(100) NOT NULL,
+    usage_amount NUMERIC NOT NULL,
+    usage_unit VARCHAR(50) NOT NULL,
+    cost_amount NUMERIC NOT NULL,
+    currency VARCHAR(10) DEFAULT 'ZAR'
+);
+
+-- Turn the standard Postgres table into a TimescaleDB Hypertable partitioned by time
+-- This chunks the data under the hood for massive performance gains
+SELECT create_hypertable('normalized_metrics', 'recorded_at');
+
+-- Create an index to make querying by environment and resource lightning fast
+-- When a user opens their dashboard, the first thing the system does is filter for their specific cloud accounts 
+-- and the most recent costs ordered in DESC order (newest timestamps at the top of the index).
+CREATE INDEX ix_environment_time ON normalized_metrics (environment_id, recorded_at DESC);

--- a/persistence/analytics/analytics-schema.sql
+++ b/persistence/analytics/analytics-schema.sql
@@ -1,15 +1,11 @@
--- AnalyticsDB init script
 CREATE EXTENSION IF NOT EXISTS timescaledb;
 
--- Provides a valid foreign key target for the normalized_metrics table.
--- Enables cross-cloud cost comparison by storing the 'provider' (AWS/GCP/AZURE).
 CREATE TABLE environment_reference (
     environment_id UUID PRIMARY KEY,
-    provider VARCHAR(50) NOT NULL, -- 'AWS', 'GCP', or 'AZURE'
+    provider VARCHAR(50) NOT NULL,
     created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
--- This stores the output of the Normalizer service
 CREATE TABLE normalized_metrics (
     recorded_at TIMESTAMPTZ NOT NULL,
     environment_id UUID REFERENCES environment_reference(environment_id),
@@ -21,11 +17,6 @@ CREATE TABLE normalized_metrics (
     currency VARCHAR(10) DEFAULT 'ZAR'
 );
 
--- Turn the standard Postgres table into a TimescaleDB Hypertable partitioned by time
--- This chunks the data under the hood for massive performance gains
 SELECT create_hypertable('normalized_metrics', 'recorded_at');
 
--- Create an index to make querying by environment and resource lightning fast
--- When a user opens their dashboard, the first thing the system does is filter for their specific cloud accounts 
--- and the most recent costs ordered in DESC order (newest timestamps at the top of the index).
 CREATE INDEX ix_environment_time ON normalized_metrics (environment_id, recorded_at DESC);


### PR DESCRIPTION
Closes: https://github.com/COS301-SE-2026/CloudSherpa/issues/137

This PR creates the tables for the AnalyticsDB that I **think** we would need.
It is a rough draft but I think this is something that we can work from and change easily as we need it.

The tables are clean as it will be populated by the AnalyticsEngine which uses the NormalizedTopic, where we will normalize all the data from the different cloud providers such that it fits into the AnalyticsDB in a manner that CloudSherpa can use.

Refer to `infra/README.md` for setup and to verify it.
Refer to `persistence/analytics/analytics-db.md` for in-depth explanations of the tables and their purpose.