### PR TITLE
Added cloud connector interfaces, factory, credentials, and ingestion interface

### DIFF
--- a/apps/ingestion-service/src/main/java/com/cloudsherpa/ingestion/connector/BillingCapable.java
+++ b/apps/ingestion-service/src/main/java/com/cloudsherpa/ingestion/connector/BillingCapable.java
@@ -1,0 +1,5 @@
+package com.cloudsherpa.ingestion.connector;
+
+public interface BillingCapable {
+  void ingestBilling(IngestionRequest request);
+}

--- a/apps/ingestion-service/src/main/java/com/cloudsherpa/ingestion/connector/CloudConnector.java
+++ b/apps/ingestion-service/src/main/java/com/cloudsherpa/ingestion/connector/CloudConnector.java
@@ -1,0 +1,9 @@
+package com.cloudsherpa.ingestion.connector;
+
+public interface CloudConnector {
+  String getProviderName();
+
+  void ingest(IngestionRequest request);
+
+  boolean testConnection(CloudCredentials credentials);
+}

--- a/apps/ingestion-service/src/main/java/com/cloudsherpa/ingestion/connector/CloudConnectorFactory.java
+++ b/apps/ingestion-service/src/main/java/com/cloudsherpa/ingestion/connector/CloudConnectorFactory.java
@@ -1,0 +1,25 @@
+package com.cloudsherpa.ingestion.connector;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+public class CloudConnectorFactory {
+
+  private final Map<String, CloudConnector> connectors;
+
+  public CloudConnectorFactory(List<CloudConnector> connectorList) {
+    this.connectors = connectorList.stream()
+        .collect(Collectors.toMap(
+            c -> c.getProviderName().toLowerCase(),
+            Function.identity()));
+  }
+
+  public CloudConnector getConnector(String provider) {
+    return connectors.get(provider.toLowerCase());
+  }
+}

--- a/apps/ingestion-service/src/main/java/com/cloudsherpa/ingestion/connector/CloudCredentials.java
+++ b/apps/ingestion-service/src/main/java/com/cloudsherpa/ingestion/connector/CloudCredentials.java
@@ -1,0 +1,64 @@
+package com.cloudsherpa.ingestion.connector;
+
+public class CloudCredentials {
+
+  // AWS
+  private String accessKey;
+  private String secretKey;
+
+  // Azure
+  private String tenantId;
+  private String clientId;
+  private String clientSecret;
+
+  // GCP
+  private String projectId;
+
+  public String getAccessKey() {
+    return accessKey;
+  }
+
+  public void setAccessKey(String accessKey) {
+    this.accessKey = accessKey;
+  }
+
+  public String getSecretKey() {
+    return secretKey;
+  }
+
+  public void setSecretKey(String secretKey) {
+    this.secretKey = secretKey;
+  }
+
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  public String getClientId() {
+    return clientId;
+  }
+
+  public void setClientId(String clientId) {
+    this.clientId = clientId;
+  }
+
+  public String getClientSecret() {
+    return clientSecret;
+  }
+
+  public void setClientSecret(String clientSecret) {
+    this.clientSecret = clientSecret;
+  }
+
+  public String getProjectId() {
+    return projectId;
+  }
+
+  public void setProjectId(String projectId) {
+    this.projectId = projectId;
+  }
+}

--- a/apps/ingestion-service/src/main/java/com/cloudsherpa/ingestion/connector/IngestionRequest.java
+++ b/apps/ingestion-service/src/main/java/com/cloudsherpa/ingestion/connector/IngestionRequest.java
@@ -1,0 +1,53 @@
+package com.cloudsherpa.ingestion.connector;
+
+import java.time.Instant;
+
+public class IngestionRequest {
+
+  private Instant from;
+  private Instant to;
+  private CloudCredentials credentials;
+
+  private boolean includeBilling;
+  private boolean includeUsage;
+
+  public Instant getInstantFrom() {
+    return from;
+  }
+
+  public void setInstantFrom(Instant from) {
+    this.from = from;
+  }
+
+  public Instant getInstantTo() {
+    return to;
+  }
+
+  public void setInstantTo(Instant to) {
+    this.to = to;
+  }
+
+  public CloudCredentials getCredentials() {
+    return credentials;
+  }
+
+  public void setCredentials(CloudCredentials credentials) {
+    this.credentials = credentials;
+  }
+
+  public boolean isIncludeBilling() {
+    return includeBilling;
+  }
+
+  public void setIncludeBilling(boolean includeBilling) {
+    this.includeBilling = includeBilling;
+  }
+
+  public boolean isIncludeUsage() {
+    return includeUsage;
+  }
+
+  public void setIncludeUsage(boolean includeUsage) {
+    this.includeUsage = includeUsage;
+  }
+}

--- a/apps/ingestion-service/src/main/java/com/cloudsherpa/ingestion/connector/UsageCapable.java
+++ b/apps/ingestion-service/src/main/java/com/cloudsherpa/ingestion/connector/UsageCapable.java
@@ -1,0 +1,6 @@
+package com.cloudsherpa.ingestion.connector;
+
+public interface UsageCapable {
+
+  void ingestUsage(IngestionRequest request);
+}


### PR DESCRIPTION
## TL;DR:

 The cloud connector system uses flexible, multi-inheritance structures and a central factory to manage provider-specific connectors, eliminating the need for hardcoded if/else blocks during expansion. While designed for flexibility, the system anticipates potential future refactoring to address disparate credential formats and ingestion logic across different cloud providers.

Closes #18
## Full explanation of additions:

The cloud connector interfaces aim to keep any future cloud connector implementations flexible through multiple-inheritance. Each implementation must inherit from CloudConnector, but may also inherit from UsageCapable and/or BillingCapable if the selected cloud service is capable of providing that information. 

The factory is in charge of discovery, keeping track of each connector that exists and managing access through a central interface. The mapping ensures that no if/else blocks need to exist when querying the connectors and when adding new connector classes, the factory does not need to change. 

One difficulty encountered is the differences in cloud credentials between providers. There is not enough overlap to justify an interface. If this becomes too large of a class, It may need to be split into each provider's respective credentials. This will be considered if it becomes a problem. The ingestion class also may need to change but this will be analyzed when implementing the specific connectors.