### PR TITLE
Normalizer kafka schema integration

### DIFF
--- a/apps/kafka-init/kafka_init.py
+++ b/apps/kafka-init/kafka_init.py
@@ -12,7 +12,7 @@ if broker == None:
 admin = AdminClient({
     "bootstrap.servers": broker,
     "retries": 5,
-    "retry.backoff": 2000,
+    "retry.backoff.ms": 2000,
 })
 
 # CloudSherpa kafka topics are configured here

--- a/apps/normalization-service/README.md
+++ b/apps/normalization-service/README.md
@@ -25,6 +25,18 @@ If the service needs Kafka locally, start the shared development dependencies an
 docker compose -f infra/docker-compose.yml up -d --build kafka kafka-init schema-registry
 ```
 
+Also start the ingestion service if events need to be produced either via the local server or docker container (local server preferred, containers built with production in mind, not optimized for dev currently)
+
+Locally:
+```bash
+SERVER_PORT=8081 KAFKA_BOOTSTRAP_SERVERS=localhost:29092 SCHEMA_REGISTRY_URL=http://localhost:9000 ./apps/ingestion-service/mvnw spring-boot:run
+```
+
+Docker:
+```bash
+docker compose -f infra/docker-compose.yml up -d --build ingestion-service
+```
+
 ## Development Server
 
 ```bash

--- a/apps/normalization-service/pom.xml
+++ b/apps/normalization-service/pom.xml
@@ -53,7 +53,28 @@
 			<artifactId>spring-kafka-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+                        <groupId>io.confluent</groupId>
+                        <artifactId>kafka-avro-serializer</artifactId>
+                        <version>7.8.0</version>
+                </dependency>
+
+                <!-- Apache Avro -->
+                <dependency>
+                        <groupId>org.apache.avro</groupId>
+                        <artifactId>avro</artifactId>
+                        <version>1.12.0</version>
+                </dependency>
+
 	</dependencies>
+	
+	<repositories>
+                <repository>
+                        <id>confluent</id>
+                        <url>https://packages.confluent.io/maven/</url>
+                </repository>
+        </repositories>
+
 
 	<build>
 		<plugins>
@@ -61,6 +82,24 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+                                <groupId>org.apache.avro</groupId>
+                                <artifactId>avro-maven-plugin</artifactId>
+                                <version>1.12.0</version>
+                                <executions>
+                                        <execution>
+                                                <phase>generate-sources</phase>
+                                                <goals>
+                                                        <goal>schema</goal>
+                                                </goals>
+                                                <configuration>
+                                                        <sourceDirectory>${project.basedir}/src/main/avro</sourceDirectory>
+                                                        <outputDirectory>${project.build.directory}/generated-sources/avro</outputDirectory>
+                                                </configuration>
+                                        </execution>
+                                </executions>
+                        </plugin>
+
 		</plugins>
 	</build>
 

--- a/apps/normalization-service/src/main/avro/cloud_usage_event.avsc
+++ b/apps/normalization-service/src/main/avro/cloud_usage_event.avsc
@@ -1,0 +1,14 @@
+{
+  "type": "record",
+  "name": "CloudUsageEvent",
+  "namespace": "com.cloudsherpa.events",
+  "fields": [
+    { "name": "provider", "type": "string" },
+    { "name": "accountId", "type": "string" },
+    { "name": "serviceName", "type": "string" },
+    { "name": "usageAmount", "type": "double" },
+    { "name": "cost", "type": "double" },
+    { "name": "currency", "type": "string" },
+    { "name": "timestamp", "type": "long" }
+  ]
+}

--- a/apps/normalization-service/src/main/java/com/cloudsherpa/normalization/services/NormalizationConsumer.java
+++ b/apps/normalization-service/src/main/java/com/cloudsherpa/normalization/services/NormalizationConsumer.java
@@ -1,0 +1,26 @@
+package com.cloudsherpa.normalization.services;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import com.cloudsherpa.events.CloudUsageEvent;
+
+@Service
+public class NormalizationConsumer {
+    /*
+    * Decorator says:
+    * Subscribe (attach/listen) to this topic
+    * When a message arrives
+    * - Deserialize it (according to Avro schema)
+    * - Call this method as a callback with the deserialized CloudUsageEvent as a parameter
+    * 
+    * application.properties define behaviour, Spring Boot configures for us in the absence of
+    * custom Kafka Consumer @Config class. We should try and achieve as much as possible via configuring
+    * properties and let Spring Boot do the grunt work before we consider implementing our own consumer config,
+    * but the option is available
+    */
+    @KafkaListener(topics = "${app.kafka.topics.cloud-usage}")
+    void consume(CloudUsageEvent event) {
+        System.out.println(event);
+    }
+}

--- a/apps/normalization-service/src/main/resources/application.properties
+++ b/apps/normalization-service/src/main/resources/application.properties
@@ -1,1 +1,26 @@
 spring.application.name=normalization-service
+
+spring.kafka.bootstrap-servers=${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
+
+# CloudSherpa consumers live inside consumer groups. It can be done where a consumer exists outside of
+# an consumer group, but that requires careful manual config and management. If the group does not exist
+# on the cluster, kafka creates the group.
+spring.kafka.consumer.group-id=normalization-group
+
+# If no offset exists, where should the consumer start reading
+# Earliest starts from the beginning of the topic, no messages missed
+spring.kafka.consumer.auto-offset=earliest
+
+# Kafka message in bytes -> Java String 
+spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+
+# Kafka message -> Avro Object according to schema
+spring.kafka.consumer.value-deserializer=io.confluent.kafka.serializers.KafkaAvroDeserializer
+
+# Tells kafka deserialize event into generated CloudUsageEvent object and other objects in future. 
+spring.kafka.consumer.properties.specific.avro.reader=true
+
+# Where schemas live (consumer requests schema from schema registry)
+spring.kafka.properties.schema.registry.url=${SCHEMA_REGISTRY_URL:http://localhost:8081}
+
+app.kafka.topics.cloud-usage=${CLOUD_USAGE_TOPIC:cloud-usage-events}


### PR DESCRIPTION
This PR adds dependencies and build instructions for the Normalizer Consumer Service. 

I found out one does not need to create a custom config class for each consumer and producer by default (like I did with the producer), only when you want granular control outside of what Spring Boot can automatically generate/configure :upside_down_face: The automatic configuration happens whenever `spring.kafka.*` properties are present.

I think it is a bit easier to work with than doing and understanding the config ourselves, doing it this way also reduces boilerplate. If you agree with this approach I will do the same for the consumer.

To test:
First a comment: this is not nice to start everything manually :disappointed: I am thinking of creating dev docker containers but will first need to do some research and thinking regarding how to make our lives easier. Let me know if you have recommendations.

1. Start kafka deps `docker compose -f infra/docker-compose.yml up kafka kafka-init schema-registry`
2. Start ingestion service `SERVER_PORT=8081 KAFKA_BOOTSTRAP_SERVERS=localhost:29092 SCHEMA_REGISTRY_URL=http://localhost:9000 ./apps/ingestion-service/mvnw spring-boot:run`
3. Finally start normalizer service `SERVER_PORT=8082 KAFKA_BOOTSTRAP_SERVERS=localhost:29092 SCHEMA_REGISTRY_URL=http://localhost:9000 ./apps/normalization-service/mvnw spring-boot:run`


Useful docs:
https://docs.spring.io/spring-kafka/reference/kafka/receiving-messages/listener-annotation.html
https://www.geeksforgeeks.org/java/spring-boot-kafka-consumer-example/
https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#configuration-details
https://docs.spring.io/spring-kafka/reference/kafka/serdes.html
https://docs.spring.io/spring-boot/reference/messaging/kafka.html#messaging.kafka

### Kafka init bug
Misconfigured retry, fixed while testing