### PR TITLE
Docs action trigger discrimenantly

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ on:
       - dev
     paths:
       - "docs/**"
-      # Keep strict manually selected files to trigger run according to repo structure, actions to not pick up changes in symlinked
+      # Keep strict manually selected files to trigger run according to repo structure, actions do not pick up changes in symlinked
       # files so need to add them manually here. 
       - "scripts/README.md"
       - "apps/alert-engine/README.md"
@@ -21,7 +21,7 @@ on:
       - "apps/normalization-service/README.md"
       - ".github/workflows/docs.yml"
       # Once doxygen is set up, we will have to run the workflow on code changes, since there is not any way of knowing 
-      # if doxygen was added or not, so then any docs/code change -> trigger action (uncomment below path)
+      # if doxygen comments were added or not, so then any docs/code change -> trigger action (uncomment below path)
       # - "apps/**/src/**" 
 
   # Workflow dispatch adds "run workflow" button in actions tab, if we want to manually rerun it for

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,24 @@ on:
     branches:
       - main
       - dev
+    paths:
+      - "docs/**"
+      # Keep strict manually selected files to trigger run according to repo structure, actions to not pick up changes in symlinked
+      # files so need to add them manually here. 
+      - "scripts/README.md"
+      - "apps/alert-engine/README.md"
+      - "apps/analytics-engine/README.md"
+      - "apps/dashboard-backend/README.md"
+      - "apps/dashboard-frontend/README.md"
+      - "apps/ingestion-service/README.md"
+      - "apps/intelligence-engine/README.md"
+      - "apps/kafka-init/README.md"
+      - "apps/normalization-service/README.md"
+      - ".github/workflows/docs.yml"
+      # Once doxygen is set up, we will have to run the workflow on code changes, since there is not any way of knowing 
+      # if doxygen was added or not, so then any docs/code change -> trigger action (uncomment below path)
+      # - "apps/**/src/**" 
+
   # Workflow dispatch adds "run workflow" button in actions tab, if we want to manually rerun it for
   # docs on main for example
   workflow_dispatch:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,9 +7,10 @@ on:
       - main
       - dev
     paths:
-      - "docs/**"
       # Keep strict manually selected files to trigger run according to repo structure, actions do not pick up changes in symlinked
       # files so need to add them manually here. 
+      - "docs/**"
+      - "mkdocs.yml"
       - "scripts/README.md"
       - "apps/alert-engine/README.md"
       - "apps/analytics-engine/README.md"


### PR DESCRIPTION
Documentation building and deployment action now triggers only when selected documentation files change, preventing unnecessary runs on every push to dev.