### PR TITLE
Schema and persistence docs setup

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,13 @@ Welcome to the CloudSherpa developer documentation.
 
     CloudSherpa follows a microservices architecture with event-driven communication. Each service is documented in detail, covering responsibilities and dependencies.
 
-??? note "REST API Documentation"
+??? note "Persistence Documentation"
+    [Database and Kafka Schemas](persistence/schemas.md)
+
+    Persistence documentation covers storage systems, database responsibilities, and schema references.
+
+
+<!-- ??? note "REST API Documentation"
     [REST API Documentation](api/api-placeholder.md)
 
     Swagger (OpenAPI) provides interactive documentation for all REST endpoints exposed across services.
@@ -25,4 +31,4 @@ Welcome to the CloudSherpa developer documentation.
 ??? note "Doxygen Code Reference"
     [Doxygen Documentation](doxygen/doxygen-placeholder.md)
 
-    Inline code documentation is generated using Doxygen, providing detailed reference material for classes, functions, and internal logic.
+    Inline code documentation is generated using Doxygen, providing detailed reference material for classes, functions, and internal logic. -->

--- a/docs/persistence/schemas.md
+++ b/docs/persistence/schemas.md
@@ -1,0 +1,111 @@
+# Database and Kafka Schemas
+
+This document is the schema reference for CloudSherpa persistence boundaries. It is strictly limited to:
+
+- database schemas
+- Kafka topic schemas
+- Avro schema files used by Kafka producers and consumers
+
+Implementation notes, service behavior, deployment details, and analytics query examples belong in the relevant service or persistence documents, not here.
+
+!!! warning "Mock Kafka schema"
+    The current `cloud_usage_event.avsc` schema is a mock schema. It does not reflect the real ingestion data structure.
+
+    It exists to demonstrate how schemas can be structured and to support testing Kafka configurations, producers, and consumers.
+
+## Database Schemas
+
+### Analytics Database
+
+Source schema file:
+
+`persistence/analytics/analytics-schema.sql`
+
+The analytics database is backed by PostgreSQL with TimescaleDB enabled for time-series storage.
+
+#### `environment_reference`
+
+Registry table for cloud environments/accounts known to the analytics database.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `environment_id` | `UUID` | Primary key | Unique identifier for a connected cloud environment. |
+| `provider` | `VARCHAR(50)` | `NOT NULL` | Cloud provider associated with the environment. |
+| `created_at` | `TIMESTAMPTZ` | `DEFAULT NOW()` | Timestamp for when the environment reference was created. |
+
+#### `normalized_metrics`
+
+Time-series table for normalized usage and cost metrics.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `recorded_at` | `TIMESTAMPTZ` | `NOT NULL` | Timestamp for when the usage or cost was recorded. |
+| `environment_id` | `UUID` | Foreign key to `environment_reference(environment_id)` | Environment associated with the metric. |
+| `resource_id` | `VARCHAR(255)` | `NOT NULL` | Provider resource identifier. |
+| `service_category` | `VARCHAR(100)` | `NOT NULL` | Normalized CloudSherpa service category. |
+| `usage_amount` | `NUMERIC` | `NOT NULL` | Quantity of resource usage. |
+| `usage_unit` | `VARCHAR(50)` | `NOT NULL` | Unit for `usage_amount`. |
+| `cost_amount` | `NUMERIC` | `NOT NULL` | Cost associated with the usage record. |
+| `currency` | `VARCHAR(10)` | `DEFAULT 'ZAR'` | Currency code for `cost_amount`. |
+
+#### TimescaleDB Configuration
+
+`normalized_metrics` is converted into a TimescaleDB hypertable partitioned by `recorded_at`.
+
+```sql
+SELECT create_hypertable('normalized_metrics', 'recorded_at');
+```
+
+The analytics schema also defines an index for environment and time-based lookups.
+
+```sql
+CREATE INDEX ix_environment_time ON normalized_metrics (environment_id, recorded_at DESC);
+```
+
+## Kafka Schemas
+
+### `cloud_usage_event.avsc`
+
+Current schema files:
+
+- `libs/kafka/schemas/cloud_usage_event.avsc`
+- `apps/ingestion-service/src/main/avro/cloud_usage_event.avsc`
+- `apps/normalization-service/src/main/avro/cloud_usage_event.avsc`
+
+Record name:
+
+`com.cloudsherpa.events.CloudUsageEvent`
+
+!!! warning "Mock schema only"
+    This schema is currently a mock schema. It should not be treated as the canonical structure of ingestion data.
+
+    Use it only as a reference for Avro schema layout and for testing Kafka producer/consumer wiring.
+
+#### Fields
+
+| Field | Avro Type | Description |
+|-------|-----------|-------------|
+| `provider` | `string` | Mock cloud provider identifier. |
+| `accountId` | `string` | Mock cloud account identifier. |
+| `serviceName` | `string` | Mock provider service name. |
+| `usageAmount` | `double` | Mock usage quantity. |
+| `cost` | `double` | Mock cost value. |
+| `currency` | `string` | Mock currency code. |
+| `timestamp` | `long` | Mock event timestamp. |
+
+#### Intended Use
+
+The current `cloud_usage_event.avsc` can be used to:
+
+- validate Kafka schema configuration
+- generate test producers and consumers
+- test serialization and deserialization
+- demonstrate how future Avro schemas should be structured in the repository
+
+It should not be used to make assumptions about the final ingestion payload shape.
+
+## Schema Ownership
+
+Database schema changes should update the relevant SQL schema file and this document in the same change.
+
+Kafka schema changes should update all required Avro schema locations and this document in the same change.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,12 +39,16 @@ nav:
       - Intelligence Engine: services/intelligence-engine.md
       - Kafka Init: services/kafka-init.md
       - Normalization Service: services/normalization-service.md
+
+  - Persistence:
+      - Schema Reference: persistence/schemas.md
+      - AnalyticsDB Overview: persistence/analytics-db.md
+
+  # - API Documentation:
+  #     - Placeholder: api/api-placeholder.md
   
-  - API Documentation:
-      - Placeholder: api/api-placeholder.md
-  
-  - Doxygen:
-      - Placeholder: doxygen/doxygen-placeholder.md
+  # - Doxygen:
+  #     - Placeholder: doxygen/doxygen-placeholder.md
 
 extra_css:
   - stylesheets/extra.css

--- a/persistence/analytics/analytics-db.md
+++ b/persistence/analytics/analytics-db.md
@@ -1,61 +1,22 @@
-# AnalyticsDB Schema Documentation
+# Analytics Database
 
-This database is powered by **TimescaleDB** (a time-series extension for PostgreSQL). It is specifically designed to ingest, store, and query massive amounts of standardized cloud billing data very quickly.
+The analytics database is powered by **TimescaleDB**, a time-series extension for PostgreSQL. It is designed to store normalized cloud usage and cost metrics for time-based analytics workloads.
 
-## Tables
+For the canonical table definitions, column types, constraints, hypertable configuration, and indexes, see [Database and Kafka Schemas](schemas.md#analytics-database).
 
-### `environment_reference`
+## Purpose
 
-A lookup table that acts as a registry for the connected cloud accounts. It provides the analytics engine with just enough context to group and compare costs across different cloud platforms.
+The analytics database supports queries over standardized billing and usage records after they have been normalized from provider-specific formats.
 
-**Fields:**
+It is used to:
 
-| Field | Type | Constraints | Purpose |
-|-------|------|-------------|---------|
-| `environment_id` | UUID | Primary Key | Unique system identifier for a connected cloud account. |
-| `provider` | VARCHAR(50) | NOT NULL | Standardized cloud provider name (e.g., `AWS`, `GCP`, `AZURE`). Enables easy calculation and comparison of spending across different clouds. |
-| `created_at` | TIMESTAMPTZ | DEFAULT NOW() | Timestamp when this environment was first registered. Useful for system auditing and debugging. |
+- store normalized cloud usage and cost records
+- associate usage records with connected cloud environments
+- support time-windowed analytics queries
+- support environment-specific cost and usage lookups
 
----
+## Storage Model
 
-### `normalized_metrics`
+Analytics data is stored as time-series data. The schema is optimized around recorded usage time and environment-specific lookups.
 
-Stores the standardized output from the **Normalizer** service. Takes the chaotic, varied billing formats from AWS, GCP, and Azure and unifies them into one standardized structure.
-
-**Fields:**
-
-| Field | Type | Constraints | Purpose |
-|-------|------|-------------|---------|
-| `recorded_at` | TIMESTAMPTZ | NOT NULL | The exact date/time the cost or usage occurred. TimescaleDB uses it to organize and retrieve data efficiently. |
-| `environment_id` | UUID | Foreign Key (`environment_reference`) | Links back to the cloud account. Answers: "Which cloud account incurred this cost?" |
-| `resource_id` | VARCHAR(255) | NOT NULL | Unique identifier from the cloud provider (e.g., AWS EC2 instance ID `i-0abcd1234`, GCP bucket name). Enables tracking costs down to individual resources. |
-| `service_category` | VARCHAR(100) | NOT NULL | CloudSherpa standardized service grouping (e.g., `Compute`, `Storage`, `Networking`). Allows cross-cloud aggregation regardless of provider-specific terminology. |
-| `usage_amount` | NUMERIC | NOT NULL | Raw volume of consumption (e.g., `730`, `50.5`). Tracks how much of a resource was used. |
-| `usage_unit` | VARCHAR(50) | NOT NULL | Unit of measurement (e.g., `vCPU-hours`, `GB-months`). Gives `usage_amount` real-world meaning. |
-| `cost_amount` | NUMERIC | NOT NULL | Actual money billed for this line item. Tracks financial spend. |
-| `currency` | VARCHAR(10) | DEFAULT 'ZAR' | Currency code for the cost. Defaults to South African Rand (ZAR). Ensures financial data is tracked accurately. |
-
-
-## Database Optimizations
-
-### Hypertable
-
-**SQL:**
-```sql
-SELECT create_hypertable('normalized_metrics', 'recorded_at');
-```
-
-**What it does:** Converts the standard `normalized_metrics` table into a **TimescaleDB Hypertable**, automatically partitioning it by time.
-
-**Why we need it:** This chops the massive table into smaller, time-based chunks. When the application queries data for "last week", the database doesn't scan years of history, it just grabs the specific chunks for last week, resulting in massive performance gains.
-
-### Composite Index
-
-**SQL:**
-```sql
-CREATE INDEX ix_environment_time ON normalized_metrics (environment_id, recorded_at DESC);
-```
-
-**What it does:** Creates an index organized first by account ID, then by time in descending order (newest first).
-
-**Why we need it:** When a user opens their dashboard, the system immediately queries for their account's most recent data. This index allows the database to instantly jump to exactly that subset of data without scanning the entire table.
+Schema details are intentionally kept out of this page to avoid duplicate documentation. Update [Database and Kafka Schemas](schemas.md#analytics-database) whenever the analytics database schema changes.


### PR DESCRIPTION
Added persistence tab to mkdocs site generation

I suggest we use `docs/persistence/schema.md` as our source of truth and reference for database and kafka avro schemas. @Star-shaker  I restructured the analytics db docs to live mostly in `schema.md`. Let me know if you want changes made. It is summarized since I think the schema doc might get large.

Added warnings regarding mock avro schema.

Commented out currently stubbed sections (swagger and doxygen)

Example of generated persistence mkdocs:
<img width="1816" height="900" alt="image" src="https://github.com/user-attachments/assets/7c2aed45-6c4e-414e-b85a-9264d9384f57" />
