### PR TITLE
Kafka wiring for normalizer and analytics

### DIFF
--- a/apps/analytics-engine/pom.xml
+++ b/apps/analytics-engine/pom.xml
@@ -61,13 +61,49 @@
 			<artifactId>spring-kafka-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+				<groupId>io.confluent</groupId>
+				<artifactId>kafka-avro-serializer</artifactId>
+				<version>7.8.0</version>
+		</dependency>
+
+		<!-- Apache Avro -->
+		<dependency>
+				<groupId>org.apache.avro</groupId>
+				<artifactId>avro</artifactId>
+				<version>1.12.0</version>
+		</dependency>
 	</dependencies>
+
+	<repositories>
+			<repository>
+					<id>confluent</id>
+					<url>https://packages.confluent.io/maven/</url>
+			</repository>
+	</repositories>
 
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.avro</groupId>
+				<artifactId>avro-maven-plugin</artifactId>
+				<version>1.12.0</version>
+				<executions>
+						<execution>
+								<phase>generate-sources</phase>
+								<goals>
+										<goal>schema</goal>
+								</goals>
+								<configuration>
+										<sourceDirectory>${project.basedir}/src/main/avro</sourceDirectory>
+										<outputDirectory>${project.build.directory}/generated-sources/avro</outputDirectory>
+								</configuration>
+						</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/apps/analytics-engine/src/main/avro/cloud_usage_event.avsc
+++ b/apps/analytics-engine/src/main/avro/cloud_usage_event.avsc
@@ -1,0 +1,14 @@
+{
+  "type": "record",
+  "name": "CloudUsageEvent",
+  "namespace": "com.cloudsherpa.events",
+  "fields": [
+    { "name": "provider", "type": "string" },
+    { "name": "accountId", "type": "string" },
+    { "name": "serviceName", "type": "string" },
+    { "name": "usageAmount", "type": "double" },
+    { "name": "cost", "type": "double" },
+    { "name": "currency", "type": "string" },
+    { "name": "timestamp", "type": "long" }
+  ]
+}

--- a/apps/analytics-engine/src/main/avro/sherpa_normalized_event.avsc
+++ b/apps/analytics-engine/src/main/avro/sherpa_normalized_event.avsc
@@ -1,6 +1,6 @@
 {
   "type": "record",
-  "name": "CloudUsageEventNormalized",
+  "name": "SherpaNormalizedEvent",
   "namespace": "com.cloudsherpa.events",
   "fields": [
     { "name": "provider", "type": "string" },

--- a/apps/analytics-engine/src/main/java/com/cloudsherpa/analytics/dto/MetricDTO.java
+++ b/apps/analytics-engine/src/main/java/com/cloudsherpa/analytics/dto/MetricDTO.java
@@ -2,7 +2,6 @@ package com.cloudsherpa.analytics.dto;
 
 import java.math.BigDecimal;
 import java.util.UUID;
-import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.List;
 

--- a/apps/analytics-engine/src/main/java/com/cloudsherpa/analytics/service/AnalyticsConsumer.java
+++ b/apps/analytics-engine/src/main/java/com/cloudsherpa/analytics/service/AnalyticsConsumer.java
@@ -1,0 +1,14 @@
+package com.cloudsherpa.analytics.service;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import com.cloudsherpa.events.SherpaNormalizedEvent;
+
+@Service
+public class AnalyticsConsumer {
+    @KafkaListener(topics = "${app.kafka.topics.sherpa-normalized}")
+    private void consume(SherpaNormalizedEvent event) {
+        System.out.println(event);
+    }
+}

--- a/apps/analytics-engine/src/main/resources/application.properties
+++ b/apps/analytics-engine/src/main/resources/application.properties
@@ -5,3 +5,29 @@ spring.datasource.password=${POSTGRES_PASSWORD:mock_pass}
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+spring.kafka.bootstrap-servers=${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
+
+# CloudSherpa consumers live inside consumer groups. It can be done where a consumer exists outside of
+# an consumer group, but that requires careful manual config and management. If the group does not exist
+# on the cluster, kafka creates the group.
+spring.kafka.consumer.group-id=normalization-group
+
+# If no offset exists, where should the consumer start reading
+# Earliest starts from the beginning of the topic, no messages missed
+spring.kafka.consumer.auto-offset-reset=earliest
+
+# Kafka message in bytes -> Java String 
+spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+
+# Kafka message -> Avro Object according to schema
+spring.kafka.consumer.value-deserializer=io.confluent.kafka.serializers.KafkaAvroDeserializer
+
+# Tells kafka deserialize event into generated CloudUsageEvent object and other objects in future. 
+spring.kafka.consumer.properties.specific.avro.reader=true
+
+# Where schemas live (consumer requests schema from schema registry)
+spring.kafka.properties.schema.registry.url=${SCHEMA_REGISTRY_URL:http://localhost:8081}
+
+app.kafka.topics.cloud-usage=${CLOUD_USAGE_TOPIC:cloud.usage.v1}
+app.kafka.topics.sherpa-normalized=${NORMALIZED_TOPIC:sherpa.normalized.v1}

--- a/apps/normalization-service/.env.example
+++ b/apps/normalization-service/.env.example
@@ -1,0 +1,4 @@
+KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+SCHEMA_REGISTRY_URL=http://schema-registry:8081
+CLOUD_USAGE_TOPIC=cloud.usage.v1
+NORMALIZED_TOPIC=sherpa.normalized.v1

--- a/apps/normalization-service/pom.xml
+++ b/apps/normalization-service/pom.xml
@@ -54,26 +54,26 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-                        <groupId>io.confluent</groupId>
-                        <artifactId>kafka-avro-serializer</artifactId>
-                        <version>7.8.0</version>
-                </dependency>
+				<groupId>io.confluent</groupId>
+				<artifactId>kafka-avro-serializer</artifactId>
+				<version>7.8.0</version>
+		</dependency>
 
-                <!-- Apache Avro -->
-                <dependency>
-                        <groupId>org.apache.avro</groupId>
-                        <artifactId>avro</artifactId>
-                        <version>1.12.0</version>
-                </dependency>
+		<!-- Apache Avro -->
+		<dependency>
+				<groupId>org.apache.avro</groupId>
+				<artifactId>avro</artifactId>
+				<version>1.12.0</version>
+		</dependency>
 
 	</dependencies>
 	
 	<repositories>
-                <repository>
-                        <id>confluent</id>
-                        <url>https://packages.confluent.io/maven/</url>
-                </repository>
-        </repositories>
+			<repository>
+					<id>confluent</id>
+					<url>https://packages.confluent.io/maven/</url>
+			</repository>
+	</repositories>
 
 
 	<build>
@@ -83,22 +83,22 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
 			<plugin>
-                                <groupId>org.apache.avro</groupId>
-                                <artifactId>avro-maven-plugin</artifactId>
-                                <version>1.12.0</version>
-                                <executions>
-                                        <execution>
-                                                <phase>generate-sources</phase>
-                                                <goals>
-                                                        <goal>schema</goal>
-                                                </goals>
-                                                <configuration>
-                                                        <sourceDirectory>${project.basedir}/src/main/avro</sourceDirectory>
-                                                        <outputDirectory>${project.build.directory}/generated-sources/avro</outputDirectory>
-                                                </configuration>
-                                        </execution>
-                                </executions>
-                        </plugin>
+				<groupId>org.apache.avro</groupId>
+				<artifactId>avro-maven-plugin</artifactId>
+				<version>1.12.0</version>
+				<executions>
+						<execution>
+								<phase>generate-sources</phase>
+								<goals>
+										<goal>schema</goal>
+								</goals>
+								<configuration>
+										<sourceDirectory>${project.basedir}/src/main/avro</sourceDirectory>
+										<outputDirectory>${project.build.directory}/generated-sources/avro</outputDirectory>
+								</configuration>
+						</execution>
+				</executions>
+			</plugin>
 
 		</plugins>
 	</build>

--- a/apps/normalization-service/src/main/avro/sherpa_normalized_event.avsc
+++ b/apps/normalization-service/src/main/avro/sherpa_normalized_event.avsc
@@ -1,6 +1,6 @@
 {
   "type": "record",
-  "name": "CloudUsageEventNormalized",
+  "name": "SherpaNormalizedEvent",
   "namespace": "com.cloudsherpa.events",
   "fields": [
     { "name": "provider", "type": "string" },

--- a/apps/normalization-service/src/main/java/com/cloudsherpa/normalization/services/NormalizationConsumer.java
+++ b/apps/normalization-service/src/main/java/com/cloudsherpa/normalization/services/NormalizationConsumer.java
@@ -19,8 +19,16 @@ public class NormalizationConsumer {
     * properties and let Spring Boot do the grunt work before we consider implementing our own consumer config,
     * but the option is available
     */
+
+    private final NormalizationProducer normalizationProducer;
+
+    public NormalizationConsumer(NormalizationProducer normalizationProducer) {
+        this.normalizationProducer = normalizationProducer;
+    }
+
     @KafkaListener(topics = "${app.kafka.topics.cloud-usage}")
-    void consume(CloudUsageEvent event) {
+    private void consume(CloudUsageEvent event) {
         System.out.println(event);
+        normalizationProducer.sendNormalizedEvent(event);
     }
 }

--- a/apps/normalization-service/src/main/java/com/cloudsherpa/normalization/services/NormalizationProducer.java
+++ b/apps/normalization-service/src/main/java/com/cloudsherpa/normalization/services/NormalizationProducer.java
@@ -1,0 +1,45 @@
+package com.cloudsherpa.normalization.services;
+
+import java.time.Instant;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import com.cloudsherpa.events.CloudUsageEvent;
+import com.cloudsherpa.events.SherpaNormalizedEvent;
+
+@Service
+public class NormalizationProducer {
+    private final KafkaTemplate<String, SherpaNormalizedEvent> kafkaTemplate;
+    private final String topic;
+
+    public NormalizationProducer(
+        KafkaTemplate<String, SherpaNormalizedEvent> kafkaTemplate,
+        @Value("${app.kafka.topics.sherpa-normalized}")
+        String topic
+    ) {
+        this.kafkaTemplate = kafkaTemplate;
+        this.topic = topic;
+    }
+
+    public void sendNormalizedEvent(CloudUsageEvent event) {
+        SherpaNormalizedEvent normalizedEvent = SherpaNormalizedEvent.newBuilder()
+            .setProvider(event.getProvider())
+            .setAccountId(event.getAccountId())
+            .setCreatedAt(Instant.ofEpochMilli(event.getTimestamp()))
+            .setEnvironmentId(event.getServiceName())
+            .setRecordedAt(event.getTimestamp())
+            .setResourceId("Stub Resource ID")
+            .setServiceCategory("Stub service category")
+            .setUsageUnit("Stub Usage Unit")
+            .setUsageAmount(event.getUsageAmount())
+            .setCurrency(event.getCurrency())
+            .setCostAmount(event.getCost())
+            .build();
+        
+        kafkaTemplate.send(topic, normalizedEvent.getAccountId().toString(), normalizedEvent);
+    }
+
+    
+}

--- a/apps/normalization-service/src/main/resources/application.properties
+++ b/apps/normalization-service/src/main/resources/application.properties
@@ -9,7 +9,7 @@ spring.kafka.consumer.group-id=normalization-group
 
 # If no offset exists, where should the consumer start reading
 # Earliest starts from the beginning of the topic, no messages missed
-spring.kafka.consumer.auto-offset=earliest
+spring.kafka.consumer.auto-offset-reset=earliest
 
 # Kafka message in bytes -> Java String 
 spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
@@ -20,7 +20,14 @@ spring.kafka.consumer.value-deserializer=io.confluent.kafka.serializers.KafkaAvr
 # Tells kafka deserialize event into generated CloudUsageEvent object and other objects in future. 
 spring.kafka.consumer.properties.specific.avro.reader=true
 
+# Kafka message key Java String -> Bytes 
+spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
+
+# Avro Object according to schema -> Kafka message 
+spring.kafka.producer.value-serializer=io.confluent.kafka.serializers.KafkaAvroSerializer
+
 # Where schemas live (consumer requests schema from schema registry)
 spring.kafka.properties.schema.registry.url=${SCHEMA_REGISTRY_URL:http://localhost:8081}
 
 app.kafka.topics.cloud-usage=${CLOUD_USAGE_TOPIC:cloud.usage.v1}
+app.kafka.topics.sherpa-normalized=${NORMALIZED_TOPIC:sherpa.normalized.v1}

--- a/libs/kafka/schemas/sherpa_normalized_event.avsc
+++ b/libs/kafka/schemas/sherpa_normalized_event.avsc
@@ -1,9 +1,10 @@
 {
   "type": "record",
-  "name": "CloudUsageEventNormalized",
+  "name": "SherpaNormalizedEvent",
   "namespace": "com.cloudsherpa.events",
   "fields": [
     { "name": "provider", "type": "string" },
+    { "name": "created_at", "type": { "type": "long", "logicalType": "timestamp-millis" }},
     { "name": "accountId", "type": "string" },
     { "name": "environmentId", "type": "string" },
     { "name": "recordedAt", "type": "long" },


### PR DESCRIPTION
Full Kafka wiring except alert which we will do later, this should be sufficient for demo 1. Tested by spinning up all relevant services and producing an event, event gets produced by ingestion, consumed and "normalized" by normalizer which produces event that gets consumed by analytics.

Some hiccups/important points:
- Spring boot application context relies on kafka and analyticsdb services to be up, we should handle the context initialization errors gracefully when a service is not available.
- With the avro schemas, we should provide defaults if values are not necessary, schema enforces all fields to be present, otherwise exception thrown