### PR TITLE
Normalization Interface

### DIFF
--- a/apps/normalization-service/src/main/java/com/cloudsherpa/normalization/model/NormalizationShema.md
+++ b/apps/normalization-service/src/main/java/com/cloudsherpa/normalization/model/NormalizationShema.md
@@ -1,0 +1,49 @@
+### Table Fields
+
+`metric_id`
+- Uniquely identifies each billing/usage event
+- **Why?** : attach tags, debug ingestion, trace anomalies
+
+`provider`
+- AWS / Azure / GCP
+- **Why?** : multi-cloud, mix providers
+
+`usage_start` `usage_end`
+- Represent the actual time window of usage
+- **Why?** : time-series graphs, forecasting
+
+`resource_id`
+- nullable for some costs that do not have resources
+- Identifies the specific resource (VM, bucket, etc.)
+- **Why?** : rightsizing, optimization recommendations
+
+`service`
+- Answers: “What service is costing us the most?”
+- Raw provider service (e.g. AmazonEC2, AmazonS3)
+- **Why?** : cost breakdown per service, dashboards, optimization insights
+
+`service_category`
+- Normalized category 
+- **Why?** : Compare across providers, give meaningful insights
+
+`usage_amount`
+- How much was consumed
+- **Why?** : forecasting, efficiency metrics, anomaly detection (usage spikes)
+
+`usage_unit`
+- Give meaning to the usage
+- **Why?** : compare usage
+
+`effective_cost`
+- Normalized cost (after discounts, savings plans)
+- **Why?** : Show true cost, so no misleading dashboard
+
+`currency`
+- Providers may return different currencies
+- **Why?** : Unified financial view
+
+`pricing_model`
+- Identifies pricing type: on_demand, reserved, savings_plan, spot, dedicated
+
+### Initial ERD
+[ERD](https://drive.google.com/file/d/1FTI1yyspUUmKRQ-zIwfUZSFhvivJWjwb/view?usp=sharing)

--- a/apps/normalization-service/src/main/java/com/cloudsherpa/normalization/model/NormalizedMetric.java
+++ b/apps/normalization-service/src/main/java/com/cloudsherpa/normalization/model/NormalizedMetric.java
@@ -1,5 +1,10 @@
 package com.cloudsherpa.normalization.model;
 
+// This creates a java object for each metric (corresponds to the fields in the database)
+// These are the new fields that I think we would need for CloudSherpa
+
+// I chose to keep it all in 1 table as I saw there would be a lot of joins between tables if we 
+// split the usage and billing
 public class NormalizedMetric
 {
     private String metricId;

--- a/apps/normalization-service/src/main/java/com/cloudsherpa/normalization/model/NormalizedMetric.java
+++ b/apps/normalization-service/src/main/java/com/cloudsherpa/normalization/model/NormalizedMetric.java
@@ -1,0 +1,105 @@
+package com.cloudsherpa.normalization.model;
+
+public class NormalizedMetric
+{
+    private String metricId;
+    private String provider;
+    private long usageStart;
+    private long usageEnd;
+    private String resourceId;
+    private String service;
+    private String serviceCategory;
+    private double usageAmount;
+    private String usageUnit;
+    private double effectiveCost;
+    private String currency;
+    private String pricingModel;
+
+    public NormalizedMetric(
+        String metricId,
+        String provider,
+        long usageStart,
+        long usageEnd,
+        String resourceId,
+        String service,
+        String serviceCategory,
+        double usageAmount,
+        String usageUnit,
+        double effectiveCost,
+        String currency,
+        String pricingModel
+    )
+    {
+        this.metricId = metricId;
+        this.provider = provider;
+        this.usageStart = usageStart;
+        this.usageEnd = usageEnd;
+        this.resourceId = resourceId;
+        this.service = service;
+        this.serviceCategory = serviceCategory;
+        this.usageAmount = usageAmount;
+        this.usageUnit = usageUnit;
+        this.effectiveCost = effectiveCost;
+        this.currency = currency;
+        this.pricingModel = pricingModel;
+    }
+
+    public String getMetricId() 
+    { 
+        return metricId; 
+    }
+
+    public String getProvider() 
+    {
+        return provider; 
+    }
+
+    public long getUsageStart() 
+    {
+        return usageStart; 
+    }
+    public long getUsageEnd() 
+    { 
+        return usageEnd; 
+    }
+
+    public String getResourceId() 
+    { 
+        return resourceId; 
+    }
+
+    public String getService() 
+    { 
+        return service; 
+    }
+
+    public String getServiceCategory() 
+    { 
+        return serviceCategory; 
+    }
+
+    public double getUsageAmount() 
+    { 
+        return usageAmount; 
+    }
+
+    public String getUsageUnit() 
+    { 
+        return usageUnit; 
+    }
+
+    public double getEffectiveCost() 
+    { 
+        return effectiveCost; 
+    }
+
+    public String getCurrency() 
+    { 
+        return currency; 
+    }
+
+    public String getPricingModel() 
+    { 
+        return pricingModel; 
+    }
+}

--- a/apps/normalization-service/src/main/java/com/cloudsherpa/normalization/normalizers/AwsNormalizer.java
+++ b/apps/normalization-service/src/main/java/com/cloudsherpa/normalization/normalizers/AwsNormalizer.java
@@ -1,0 +1,19 @@
+package com.cloudsherpa.normalization.normalizers;
+
+import com.cloudsherpa.normalization.model.NormalizedMetric;
+
+public class AwsNormalizer implements Normalizer
+{
+    @Override
+    public NormalizedMetric normalize(String mockRawMetrics)
+    {
+        return new NormalizedMetric("", "", 0, 0, "", "", "", 0, "", 0, "", "");
+    }
+
+    private static String normalizeCategory(String category)
+    {
+        return ""; // Map the categories from the raw data to our predefined categories that we want to show the user / use
+    }
+
+    // Other normalize functions will probably also be added if we see it is necessary
+}

--- a/apps/normalization-service/src/main/java/com/cloudsherpa/normalization/normalizers/Normalizer.java
+++ b/apps/normalization-service/src/main/java/com/cloudsherpa/normalization/normalizers/Normalizer.java
@@ -1,6 +1,9 @@
 package com.cloudsherpa.normalization.normalizers;
 
-public class Normalizer 
+import com.cloudsherpa.normalization.model.NormalizedMetric;
+
+public interface Normalizer 
 {
-    
+    // This will eventually be something like NormalizedMetric normalize(RawMetric raw);
+    NormalizedMetric normalize(String mockRawMetrics);
 }

--- a/apps/normalization-service/src/main/java/com/cloudsherpa/normalization/normalizers/Normalizer.java
+++ b/apps/normalization-service/src/main/java/com/cloudsherpa/normalization/normalizers/Normalizer.java
@@ -1,0 +1,6 @@
+package com.cloudsherpa.normalization.normalizers;
+
+public class Normalizer 
+{
+    
+}


### PR DESCRIPTION
Added Normalization interface with mock data.
### What I think:
- From `CloudConnector` we create java object, `RawMetric`
- Then the `NormalizedMetric` uses this `RawMetric` object and normalizes it based on the cloud provider (There will be 3 `Normalizers` for each provider, each inherited from the `Normalizer` class)
- Then from the Normalizer, it is written to the TimescaleDB

Refer to `NormalizationShema.md`