### PR TITLE
Pre-commit hook

### DIFF
--- a/apps/dashboard/eslint.config.mjs
+++ b/apps/dashboard/eslint.config.mjs
@@ -1,10 +1,12 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
+import prettier from 'eslint-config-prettier/flat'
 
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  prettier,
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:

--- a/apps/dashboard/package-lock.json
+++ b/apps/dashboard/package-lock.json
@@ -24,8 +24,9 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
-        "eslint": "^9",
-        "eslint-config-next": "16.2.4",
+        "eslint": "^9.39.4",
+        "eslint-config-next": "^16.2.4",
+        "eslint-config-prettier": "^10.1.8",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -5925,6 +5926,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -25,8 +25,9 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "eslint": "^9",
-    "eslint-config-next": "16.2.4",
+    "eslint": "^9.39.4",
+    "eslint-config-next": "^16.2.4",
+    "eslint-config-prettier": "^10.1.8",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/docs/dev/MonorepoMadness.md
+++ b/docs/dev/MonorepoMadness.md
@@ -2,6 +2,14 @@
 
 This document explains where things live in the CloudSherpa repository and where new files should go. It is intentionally focused on directory. For service-specific setup, commands, ports, dependencies, and environment details, use the service READMEs under `apps/`.
 
+!!! important "Do this first"
+
+    After cloning the repository, configure Git to use the shared hook scripts before making commits:
+
+    ```bash
+    git config core.hooksPath scripts/hooks
+    ```
+
 ## Branching Strategy
 
 To maintain code quality and deployment stability, we strictly follow a main/dev/feature branch strategy:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,14 @@
 
 This directory contains scripts intended for configuring the repo, installing dev dependencies and automating the CloudSherpa dev environments.
 
+!!! important "First-time setup"
+
+    Before running development scripts or making commits in this repository, configure Git to use the repo-managed hooks:
+
+    ```bash
+    git config core.hooksPath scripts/hooks
+    ```
+
 | Script Name        | Script Purpose                                      |
 |--------------------|-----------------------------------------------------|
 | **env-init.sh**      | Recursively finds and safely copies `.env.example` files to `.env` files. Each service depends on its own isolated environment variables as far as possible. Shared environment variables are configured in the root `.env`. Script behaviour and usage is further documented via comments made in the file itself. |

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -eo pipefail
+
+INFO='\033[1;34m'     
+SUCCESS='\033[1;32m'  
+RESET='\033[0m'
+ERROR='\033[1;31m'
+
+echo -e "${INFO}Running CloudSherpa Dashboard Lint...${RESET}"
+(cd apps/dashboard && npx eslint . >/dev/null 2>&1 || {
+	echo -e "${ERROR}Dashboard lint failed. Run \"npm lint\" in apps/dashbaord for more verbose error messages. Commit not made.${RESET}"
+	exit 1
+})
+echo -e "${SUCCESS}Dashboard lint succeeded${RESET}"
+echo -e "${SUCCESS}Succesfully made a commit, congrats!${RESET}"


### PR DESCRIPTION
Set up pre commit hook for running linting, this way we ensure only code that pass lints ever gets pushed to remote. Linting fails = no commit.

**Important** each developer will have to run
```sh
git config core.hooksPath scripts/hooks
```
To tell git where to find its hooks. This is a once off thing, but very important that each person does this before making another commit when they have pulled dev into their branches after this is merged.

Added prettier to ensure consistent formatting for the dashboard code.

Example of successful commit:
<img width="671" height="117" alt="image" src="https://github.com/user-attachments/assets/62a14f64-1305-4b1c-9771-76bc4ecb9821" />
