### PR TITLE
Java checkstyle linting

### DIFF
--- a/apps/ingestion/config/checkstyle/checkstyle.xml
+++ b/apps/ingestion/config/checkstyle/checkstyle.xml
@@ -1,0 +1,487 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+    Checkstyle configuration that checks the Google coding conventions from Google Java Style
+    that can be found at https://google.github.io/styleguide/javaguide.html
+
+    Checkstyle is very configurable. Be sure to read the documentation at
+    http://checkstyle.org (or in your downloaded distribution).
+
+    To completely disable a check, just comment it out or delete it from the file.
+    To suppress certain violations please review suppression filters.
+
+    Authors: Max Vetrenko, Mauryan Kansara, Ruslan Diachenko, Roman Ivanov.
+ -->
+
+<module name="Checker">
+
+  <property name="charset" value="UTF-8"/>
+
+  <property name="severity" value="${org.checkstyle.google.severity}" default="warning"/>
+
+  <property name="fileExtensions" value="java, properties, xml"/>
+  <!-- Excludes all 'module-info.java' files              -->
+  <!-- See https://checkstyle.org/filefilters/index.html -->
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="module\-info\.java$"/>
+  </module>
+
+  <module name="SuppressWarningsFilter"/>
+
+  <!-- https://checkstyle.org/filters/suppressionfilter.html -->
+  <module name="SuppressionFilter">
+    <property name="file" value="${org.checkstyle.google.suppressionfilter.config}"
+           default="checkstyle-suppressions.xml" />
+    <property name="optional" value="true"/>
+  </module>
+
+  <!-- https://checkstyle.org/filters/suppresswithnearbytextfilter.html -->
+  <module name="SuppressWithNearbyTextFilter">
+    <property name="nearbyTextPattern"
+              value="CHECKSTYLE.SUPPRESS\: (\w+) for ([+-]\d+) lines"/>
+    <property name="checkPattern" value="$1"/>
+    <property name="lineRange" value="$2"/>
+  </module>
+
+  <!-- Checks for whitespace                               -->
+  <!-- See http://checkstyle.org/checks/whitespace/index.html -->
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+
+  <module name="LineLength">
+    <property name="fileExtensions" value="java"/>
+    <property name="max" value="100"/>
+    <property name="ignorePattern"
+             value="^package.*|^import.*|href\s*=\s*&quot;[^&quot;]*&quot;|http://|https://|ftp://"/>
+  </module>
+  <!--  Suppression to prevent LineLength Check from flagging lines in Text-blocks -->
+  <module name="SuppressWithPlainTextCommentFilter">
+    <property name="checkFormat" value="LineLength"/>
+    <property name="offCommentFormat" value='^.*"""\s*$'/>
+    <property name="onCommentFormat" value='^\s*"""\s*(?:[,;]|.+)$'/>
+  </module>
+  <module name="SuppressWithPlainTextCommentFilter">
+    <property name="checkFormat" value="IndentationCheck"/>
+    <property name="offCommentFormat" value='^""".?'/>
+    <property name="onCommentFormat" value='.'/>
+  </module>
+  <module name="TreeWalker">
+    <module name="OuterTypeFilename"/>
+    <module name="MatchXpath">
+      <property name="id" value="singleLineCommentStartWithSpace"/>
+      <property name="query"
+                value="//SINGLE_LINE_COMMENT[./COMMENT_CONTENT[not(starts-with(@text, ' '))
+                       and not(starts-with(@text, '/'))
+                       and not(@text = '\n') and not(ends-with(@text, '//\n'))]]"/>
+      <message key="matchxpath.match" value="''//'' must be followed by a whitespace."/>
+    </module>
+    <module name="IllegalTokenText">
+      <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL, TEXT_BLOCK_CONTENT"/>
+      <property name="format"
+          value="\\u00(08|09|0(a|A)|0(c|C)|0(d|D)|20|22|27|5(C|c))|\\(0(10|11|12|14|15|40|42|47)|134)"/>
+      <property name="message"
+               value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
+    </module>
+    <module name="AvoidEscapedUnicodeCharacters">
+      <property name="allowEscapesForControlCharacters" value="true"/>
+      <property name="allowByTailComment" value="true"/>
+      <property name="allowNonPrintableEscapes" value="true"/>
+    </module>
+    <module name="AvoidStarImport"/>
+    <module name="OneTopLevelClass"/>
+    <module name="NoLineWrap">
+      <property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT"/>
+    </module>
+    <module name="NeedBraces">
+      <property name="tokens"
+               value="LITERAL_DO, LITERAL_ELSE, LITERAL_FOR, LITERAL_IF, LITERAL_WHILE"/>
+    </module>
+    <module name="LeftCurly">
+      <property name="id" value="LeftCurlyEol"/>
+      <property name="tokens"
+                value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF,
+                    INTERFACE_DEF, LAMBDA, LITERAL_CATCH,
+                    LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, METHOD_DEF,
+                    OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF, SWITCH_RULE"/>
+    </module>
+    <module name="LeftCurly">
+      <property name="id" value="LeftCurlyNl"/>
+      <property name="option" value="nl"/>
+      <property name="tokens"
+                value="LITERAL_CASE, LITERAL_DEFAULT"/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <!-- LITERAL_CASE, LITERAL_DEFAULT are reused in SWITCH_RULE  -->
+      <property name="id" value="LeftCurlyNl"/>
+      <property name="query" value="//SWITCH_RULE/SLIST"/>
+    </module>
+    <module name="RightCurly">
+      <property name="id" value="RightCurlySame"/>
+      <property name="tokens"
+                value="LITERAL_TRY, LITERAL_CATCH, LITERAL_IF, LITERAL_ELSE,
+                    LITERAL_DO"/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <property name="id" value="RightCurlySame"/>
+      <property name="query" value="//RCURLY[parent::SLIST[parent::LITERAL_CATCH
+                               and not(parent::LITERAL_CATCH/following-sibling::*)]]"/>
+    </module>
+    <module name="RightCurly">
+      <property name="id" value="RightCurlyAlone"/>
+      <property name="option" value="alone"/>
+      <property name="tokens"
+               value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
+                    INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,
+                    COMPACT_CTOR_DEF, LITERAL_SWITCH, LITERAL_CASE, LITERAL_FINALLY,
+                    LITERAL_CATCH"/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <!-- suppression is required till https://github.com/checkstyle/checkstyle/issues/7541 -->
+      <property name="id" value="RightCurlyAlone"/>
+      <property name="query" value="//RCURLY[parent::SLIST[count(./*)=1
+                               and not(parent::LITERAL_CATCH)]
+                               or (preceding-sibling::*[last()][self::LCURLY]
+                               and not(parent::SLIST/parent::LITERAL_CATCH))
+                               or (parent::SLIST/parent::LITERAL_CATCH
+                               and parent::SLIST/parent::LITERAL_CATCH/following-sibling::*)]"/>
+    </module>
+    <module name="WhitespaceAfter">
+      <property name="tokens"
+               value="COMMA, SEMI, TYPECAST, ELLIPSIS, LITERAL_YIELD, LITERAL_CASE, ANNOTATIONS"/>
+    </module>
+    <module name="WhitespaceAround">
+      <property name="allowEmptyConstructors" value="true"/>
+      <property name="allowEmptyLambdas" value="true"/>
+      <property name="allowEmptyMethods" value="true"/>
+      <property name="allowEmptyTypes" value="true"/>
+      <property name="allowEmptyLoops" value="true"/>
+      <property name="allowEmptySwitchBlockStatements" value="true"/>
+      <property name="ignoreEnhancedForColon" value="false"/>
+      <property name="tokens"
+               value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR,
+                    BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND,
+                    LCURLY, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY,
+                    LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SWITCH, LITERAL_SYNCHRONIZED,
+                    LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN,
+                    NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, RCURLY, SL, SLIST, SL_ASSIGN, SR,
+                    SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT,
+                    TYPE_EXTENSION_AND, LITERAL_WHEN"/>
+      <message key="ws.notFollowed"
+              value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks
+               may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
+      <message key="ws.notPreceded"
+              value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <property name="checks" value="WhitespaceAround"/>
+      <property name="query" value="//*[self::LITERAL_IF or self::LITERAL_ELSE or
+                                 self::STATIC_INIT]/SLIST[count(./*)=1]
+                                 | //*[self::STATIC_INIT or self::LITERAL_TRY or self::LITERAL_IF]
+                                 //*[self::RCURLY][parent::SLIST[count(./*)=1]]
+                                 | //SLIST[count(./*)=1][parent::LITERAL_TRY and
+                                 not(following-sibling::*)]
+                                 | //SLIST[count(./*)=1][parent::LITERAL_CATCH and
+                                 not(parent::LITERAL_CATCH/following-sibling::*)]"/>
+    </module>
+    <module name="RegexpSinglelineJava">
+      <property name="format" value="\{[ ]+\}"/>
+      <property name="message" value="Empty blocks should have no spaces. Empty blocks
+                                   may only be represented as '{}' when not part of a
+                                   multi-block statement (4.1.3)"/>
+    </module>
+    <module name="OneStatementPerLine"/>
+    <module name="MultipleVariableDeclarations"/>
+    <module name="ArrayTypeStyle"/>
+    <!-- <module name="JavadocLeadingAsteriskAlign"/>
+    <module name="JavadocMissingLeadingAsterisk"/>
+    <module name="JavadocContentLocation"/> -->
+    <module name="MissingSwitchDefault"/>
+    <module name="FallThrough"/>
+    <module name="UpperEll"/>
+    <module name="ModifierOrder"/>
+    <module name="TextBlockGoogleStyleFormatting"/>
+    <module name="EmptyLineSeparator">
+      <property name="tokens"
+               value="PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                    STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF, RECORD_DEF,
+                    COMPACT_CTOR_DEF"/>
+      <property name="allowNoEmptyLineBetweenFields" value="true"/>
+      <property name="allowMultipleEmptyLines" value="false"/>
+    </module>
+    <module name="SeparatorWrap">
+      <property name="id" value="SeparatorWrapDot"/>
+      <property name="tokens" value="DOT"/>
+      <property name="option" value="nl"/>
+    </module>
+    <module name="SeparatorWrap">
+      <property name="id" value="SeparatorWrapComma"/>
+      <property name="tokens" value="COMMA"/>
+      <property name="option" value="EOL"/>
+    </module>
+    <module name="SeparatorWrap">
+      <!-- ELLIPSIS is EOL until https://github.com/google/styleguide/issues/259 -->
+      <property name="id" value="SeparatorWrapEllipsis"/>
+      <property name="tokens" value="ELLIPSIS"/>
+      <property name="option" value="EOL"/>
+    </module>
+    <module name="SeparatorWrap">
+      <!-- ARRAY_DECLARATOR is EOL until https://github.com/google/styleguide/issues/258 -->
+      <property name="id" value="SeparatorWrapArrayDeclarator"/>
+      <property name="tokens" value="ARRAY_DECLARATOR"/>
+      <property name="option" value="EOL"/>
+    </module>
+    <module name="SeparatorWrap">
+      <property name="id" value="SeparatorWrapMethodRef"/>
+      <property name="tokens" value="METHOD_REF"/>
+      <property name="option" value="nl"/>
+    </module>
+    <module name="PackageName">
+      <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+      <message key="name.invalidPattern"
+             value="Package name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="TypeName">
+      <property name="format" value="^[A-Z][a-zA-Z0-9]*(?:[0-9](?:_[0-9]+)*)?$"/>
+      <property name="tokens" value="CLASS_DEF"/>
+      <message key="name.invalidPattern"
+             value="Type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="TypeName">
+      <property name="tokens" value="INTERFACE_DEF, ENUM_DEF,
+                    ANNOTATION_DEF, RECORD_DEF"/>
+      <message key="name.invalidPattern"
+             value="Type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="GoogleNonConstantFieldName"/>
+    <module name="ParameterName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+             value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="LambdaParameterName">
+      <property name="format" value="^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$"/>
+      <message key="name.invalidPattern"
+             value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="CatchParameterName">
+      <property name="format" value="^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$"/>
+      <message key="name.invalidPattern"
+             value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="LocalVariableName">
+      <property name="format" value="^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$"/>
+      <message key="name.invalidPattern"
+             value="Local variable name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="PatternVariableName">
+      <property name="format" value="^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$"/>
+      <message key="name.invalidPattern"
+             value="Pattern variable name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="ClassTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+             value="Class type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="RecordComponentName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+               value="Record component name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="RecordTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+               value="Record type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="MethodTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+             value="Method type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="InterfaceTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+             value="Interface type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="NoFinalizer"/>
+    <module name="GenericWhitespace">
+      <message key="ws.followed"
+             value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+      <message key="ws.preceded"
+             value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+      <message key="ws.illegalFollow"
+             value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+      <message key="ws.notPreceded"
+             value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+    </module>
+    <module name="Indentation">
+      <property name="basicOffset" value="2"/>
+      <property name="braceAdjustment" value="2"/>
+      <property name="caseIndent" value="2"/>
+      <property name="throwsIndent" value="4"/>
+      <property name="lineWrappingIndentation" value="4"/>
+      <property name="arrayInitIndent" value="2"/>
+    </module>
+
+    <module name="AbbreviationAsWordInName">
+      <property name="ignoreFinal" value="false"/>
+      <property name="allowedAbbreviationLength" value="0"/>
+      <property name="tokens"
+               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,
+                    PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF,
+                    RECORD_COMPONENT_DEF"/>
+    </module>
+    <module name="NoWhitespaceBeforeCaseDefaultColon"/>
+    <module name="OverloadMethodsDeclarationOrder"/>
+    <module name="ConstructorsDeclarationGrouping"/>
+    <module name="VariableDeclarationUsageDistance"/>
+    <module name="CustomImportOrder">
+      <property name="sortImportsInGroupAlphabetically" value="true"/>
+      <property name="separateLineBetweenGroups" value="true"/>
+      <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
+    </module>
+    <module name="MethodParamPad">
+      <property name="tokens"
+               value="CTOR_DEF, LITERAL_NEW, METHOD_CALL, METHOD_DEF, CTOR_CALL,
+                    SUPER_CTOR_CALL, ENUM_CONSTANT_DEF, RECORD_DEF, RECORD_PATTERN_DEF"/>
+    </module>
+    <module name="NoWhitespaceBefore">
+      <property name="tokens"
+               value="COMMA, SEMI, POST_INC, POST_DEC, DOT,
+                    LABELED_STAT, METHOD_REF, ELLIPSIS"/>
+      <property name="allowLineBreaks" value="true"/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <property name="checks" value="NoWhitespaceBefore"/>
+      <property name="query"
+          value="//ELLIPSIS[preceding-sibling::TYPE/ANNOTATIONS[ANNOTATION[LPAREN]
+              or not(following-sibling::*)]]"/>
+    </module>
+    <module name="ParenPad">
+      <property name="tokens"
+               value="ANNOTATION, ANNOTATION_FIELD_DEF, CTOR_CALL, CTOR_DEF, DOT, ENUM_CONSTANT_DEF,
+                    EXPR, LITERAL_CATCH, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_NEW,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_WHILE, METHOD_CALL,
+                    METHOD_DEF, QUESTION, RESOURCE_SPECIFICATION, SUPER_CTOR_CALL, LAMBDA,
+                    RECORD_DEF, RECORD_PATTERN_DEF"/>
+    </module>
+    <module name="OperatorWrap">
+      <property name="option" value="NL"/>
+      <property name="tokens"
+               value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR,
+                    LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF,
+                    TYPE_EXTENSION_AND "/>
+    </module>
+    <module name="AnnotationLocation">
+      <property name="id" value="AnnotationLocationTypeAndPackage"/>
+      <property name="tokens"
+               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, RECORD_DEF, PACKAGE_DEF"/>
+      <property name="allowSamelineSingleParameterlessAnnotation" value="false"/>
+    </module>
+    <module name="AnnotationLocation">
+      <property name="id" value="AnnotationLocationMethodsAndCtors"/>
+      <property name="tokens"
+               value="METHOD_DEF, CTOR_DEF, COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="AnnotationLocation">
+      <property name="id" value="AnnotationLocationVariables"/>
+      <property name="tokens" value="VARIABLE_DEF"/>
+      <property name="allowSamelineMultipleAnnotations" value="true"/>
+    </module>
+    <module name="MissingOverrideOnRecordAccessor"/>
+    <module name="NonEmptyAtclauseDescription"/>
+    <!-- <module name="InvalidJavadocPosition"/> -->
+    <!-- <module name="JavadocTagContinuationIndentation"/>
+    <module name="SummaryJavadoc">
+      <property name="forbiddenSummaryFragments"
+        value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )|^[a-z]"/>
+    </module>
+    <module name="JavadocParagraph">
+      <property name="allowNewlineParagraph" value="false"/>
+    </module> -->
+    <module name="RequireEmptyLineBeforeBlockTagGroup"/>
+    <module name="AtclauseOrder">
+      <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
+      <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF,
+                                  VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF"/>
+    </module>
+    <!-- <module name="JavadocMethod">
+      <property name="accessModifiers" value="public"/>
+      <property name="allowMissingParamTags" value="true"/>
+      <property name="allowMissingReturnTag" value="true"/>
+      <property name="allowedAnnotations" value="Override, Test"/>
+      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF"/>
+    </module> -->
+    <!-- <module name="MissingJavadocMethod">
+      <property name="scope" value="protected"/>
+      <property name="allowMissingPropertyJavadoc" value="true"/>
+      <property name="allowedAnnotations" value="Override, Test"/>
+      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF,
+                                   COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <property name="checks" value="MissingJavadocMethod"/>
+      <property name="query" value="//*[self::METHOD_DEF or self::CTOR_DEF
+                                 or self::ANNOTATION_FIELD_DEF or self::COMPACT_CTOR_DEF]
+                                 [ancestor::*[self::INTERFACE_DEF or self::CLASS_DEF
+                                 or self::RECORD_DEF or self::ENUM_DEF]
+                                 [not(./MODIFIERS/LITERAL_PUBLIC)]]"/>
+    </module>
+    <module name="MissingJavadocType">
+      <property name="scope" value="protected"/>
+      <property name="tokens"
+                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                      RECORD_DEF, ANNOTATION_DEF"/>
+      <property name="excludeScope" value="nothing"/>
+    </module> -->
+    <module name="MethodName">
+      <property name="format"
+          value="^(?![a-z]$)(?![a-z][A-Z])[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*(?:_[0-9]+)*$"/>
+      <message key="name.invalidPattern"
+             value="Method name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <property name="checks" value="MethodName"/>
+      <property name="query" value="//METHOD_DEF[
+                                     ./MODIFIERS/ANNOTATION//IDENT[contains(@text, 'Test')]
+                                   ]/IDENT"/>
+      <property name="message" value="'[a-z][a-z0-9][a-zA-Z0-9]*(?:_[a-z][a-z0-9][a-zA-Z0-9]*)*'"/>
+    </module>
+    <!-- <module name="SingleLineJavadoc"/> -->
+    <module name="TodoComment">
+      <property name="format" value="^[ \t]*(?!TODO:)(?i:TODO)\b:?"/>
+      <message key="todo.match"
+               value="''TODO:'' must be written in all caps and followed by a colon."/>
+    </module>
+    <module name="EmptyCatchBlock">
+      <property name="commentFormat" value="\w+"/>
+    </module>
+    <module name="CommentsIndentation">
+      <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN"/>
+    </module>
+    <!-- https://checkstyle.org/filters/suppressionxpathfilter.html -->
+    <module name="SuppressionXpathFilter">
+      <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"
+             default="checkstyle-xpath-suppressions.xml" />
+      <property name="optional" value="true"/>
+    </module>
+    <module name="SuppressWarningsHolder" />
+    <module name="SuppressionCommentFilter">
+      <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)" />
+      <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)" />
+      <property name="checkFormat" value="$1" />
+    </module>
+    <module name="SuppressWithNearbyCommentFilter">
+      <property name="commentFormat" value="CHECKSTYLE.SUPPRESS\: ([\w\|]+)"/>
+      <!-- $1 refers to the first match group in the regex defined in commentFormat -->
+      <property name="checkFormat" value="$1"/>
+      <!-- The check is suppressed in the next line of code after the comment -->
+      <property name="influenceFormat" value="1"/>
+    </module>
+  </module>
+</module>

--- a/apps/ingestion/pom.xml
+++ b/apps/ingestion/pom.xml
@@ -1,30 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.5.7</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.cloudsherpa</groupId>
 	<artifactId>ingestion</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>ingestion</name>
-	<description/>
-	<url/>
+	<description />
+	<url />
 	<licenses>
-		<license/>
+		<license />
 	</licenses>
 	<developers>
-		<developer/>
+		<developer />
 	</developers>
 	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
+		<connection />
+		<developerConnection />
+		<tag />
+		<url />
 	</scm>
 	<properties>
 		<java.version>21</java.version>
@@ -65,6 +66,54 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>3.6.0</version>
+				<dependencies>
+					<dependency>
+						<groupId>com.puppycrawl.tools</groupId>
+						<artifactId>checkstyle</artifactId>
+						<version>13.4.2</version>
+					</dependency>
+				</dependencies>
+				<configuration>
+					<configLocation>config/checkstyle/checkstyle.xml</configLocation>
+					<consoleOutput>true</consoleOutput>
+					<failsOnError>true</failsOnError>
+					<linkXRef>false</linkXRef>
+				</configuration>
+				<executions>
+					<execution>
+						<id>validate</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>com.diffplug.spotless</groupId>
+				<artifactId>spotless-maven-plugin</artifactId>
+				<version>2.43.0</version>
+
+				<configuration>
+					<java>
+						<googleJavaFormat>
+							<version>1.17.0</version>
+						</googleJavaFormat>
+					</java>
+				</configuration>
+
+				<executions>
+					<execution>
+						<goals>
+							<goal>apply</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/IngestionApplication.java
+++ b/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/IngestionApplication.java
@@ -6,8 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class IngestionApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(IngestionApplication.class, args);
-	}
-
+  public static void main(String[] args) {
+    SpringApplication.run(IngestionApplication.class, args);
+  }
 }

--- a/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/connector/CloudConnectorFactory.java
+++ b/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/connector/CloudConnectorFactory.java
@@ -1,11 +1,10 @@
 package com.cloudsherpa.ingestion.connector;
 
-import org.springframework.stereotype.Component;
-
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
 
 @Component
 public class CloudConnectorFactory {
@@ -13,10 +12,9 @@ public class CloudConnectorFactory {
   private final Map<String, CloudConnector> connectors;
 
   public CloudConnectorFactory(List<CloudConnector> connectorList) {
-    this.connectors = connectorList.stream()
-        .collect(Collectors.toMap(
-            c -> c.getProviderName().toLowerCase(),
-            Function.identity()));
+    this.connectors =
+        connectorList.stream()
+            .collect(Collectors.toMap(c -> c.getProviderName().toLowerCase(), Function.identity()));
   }
 
   public CloudConnector getConnector(String provider) {

--- a/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/connector/IngestionRequest.java
+++ b/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/connector/IngestionRequest.java
@@ -1,7 +1,6 @@
 package com.cloudsherpa.ingestion.connector;
 
 import java.time.Instant;
-
 import java.util.List;
 
 public class IngestionRequest {

--- a/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/controller/CloudUsageController.java
+++ b/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/controller/CloudUsageController.java
@@ -1,26 +1,24 @@
 package com.cloudsherpa.ingestion.controller;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.cloudsherpa.ingestion.normalization.model.NormalizedMetric;
 import com.cloudsherpa.ingestion.service.CloudUsageService;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/events")
 public class CloudUsageController {
-    private final CloudUsageService cloudUsageService;
+  private final CloudUsageService cloudUsageService;
 
-    // CloudUsageService injected as dependency of CloudUsageController
-    public CloudUsageController(CloudUsageService cloudUsageService) {
-        this.cloudUsageService = cloudUsageService;
-    }
+  // CloudUsageService injected as dependency of CloudUsageController
+  public CloudUsageController(CloudUsageService cloudUsageService) {
+    this.cloudUsageService = cloudUsageService;
+  }
 
-    // POST even though no request body, produce artifact (metric) => POST
-    @PostMapping("/mock")
-    public NormalizedMetric sendMockEvent() {
-        return cloudUsageService.sendMockEvent();
-    }
-    
+  // POST even though no request body, produce artifact (metric) => POST
+  @PostMapping("/mock")
+  public NormalizedMetric sendMockEvent() {
+    return cloudUsageService.sendMockEvent();
+  }
 }

--- a/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/normalization/model/NormalizedMetric.java
+++ b/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/normalization/model/NormalizedMetric.java
@@ -3,108 +3,94 @@ package com.cloudsherpa.ingestion.normalization.model;
 // This creates a java object for each metric (corresponds to the fields in the database)
 // These are the new fields that I think we would need for CloudSherpa
 
-// I chose to keep it all in 1 table as I saw there would be a lot of joins between tables if we 
+// I chose to keep it all in 1 table as I saw there would be a lot of joins between tables if we
 // split the usage and billing
-public class NormalizedMetric
-{
-    private String metricId;
-    private String provider;
-    private long usageStart;
-    private long usageEnd;
-    private String resourceId;
-    private String service;
-    private String serviceCategory;
-    private double usageAmount;
-    private String usageUnit;
-    private double effectiveCost;
-    private String currency;
-    private String pricingModel;
+public class NormalizedMetric {
+  private String metricId;
+  private String provider;
+  private long usageStart;
+  private long usageEnd;
+  private String resourceId;
+  private String service;
+  private String serviceCategory;
+  private double usageAmount;
+  private String usageUnit;
+  private double effectiveCost;
+  private String currency;
+  private String pricingModel;
 
-    public NormalizedMetric(
-        String metricId,
-        String provider,
-        long usageStart,
-        long usageEnd,
-        String resourceId,
-        String service,
-        String serviceCategory,
-        double usageAmount,
-        String usageUnit,
-        double effectiveCost,
-        String currency,
-        String pricingModel
-    )
-    {
-        this.metricId = metricId;
-        this.provider = provider;
-        this.usageStart = usageStart;
-        this.usageEnd = usageEnd;
-        this.resourceId = resourceId;
-        this.service = service;
-        this.serviceCategory = serviceCategory;
-        this.usageAmount = usageAmount;
-        this.usageUnit = usageUnit;
-        this.effectiveCost = effectiveCost;
-        this.currency = currency;
-        this.pricingModel = pricingModel;
-    }
+  public NormalizedMetric(
+      String metricId,
+      String provider,
+      long usageStart,
+      long usageEnd,
+      String resourceId,
+      String service,
+      String serviceCategory,
+      double usageAmount,
+      String usageUnit,
+      double effectiveCost,
+      String currency,
+      String pricingModel) {
+    this.metricId = metricId;
+    this.provider = provider;
+    this.usageStart = usageStart;
+    this.usageEnd = usageEnd;
+    this.resourceId = resourceId;
+    this.service = service;
+    this.serviceCategory = serviceCategory;
+    this.usageAmount = usageAmount;
+    this.usageUnit = usageUnit;
+    this.effectiveCost = effectiveCost;
+    this.currency = currency;
+    this.pricingModel = pricingModel;
+  }
 
-    public String getMetricId() 
-    { 
-        return metricId; 
-    }
+  public String getMetricId() {
+    return metricId;
+  }
 
-    public String getProvider() 
-    {
-        return provider; 
-    }
+  public String getProvider() {
+    return provider;
+  }
 
-    public long getUsageStart() 
-    {
-        return usageStart; 
-    }
-    public long getUsageEnd() 
-    { 
-        return usageEnd; 
-    }
+  public long getUsageStart() {
+    return usageStart;
+  }
 
-    public String getResourceId() 
-    { 
-        return resourceId; 
-    }
+  public long getUsageEnd() {
+    return usageEnd;
+  }
 
-    public String getService() 
-    { 
-        return service; 
-    }
+  public String getResourceId() {
+    return resourceId;
+  }
 
-    public String getServiceCategory() 
-    { 
-        return serviceCategory; 
-    }
+  public String getService() {
+    return service;
+  }
 
-    public double getUsageAmount() 
-    { 
-        return usageAmount; 
-    }
+  public String getServiceCategory() {
+    return serviceCategory;
+  }
 
-    public String getUsageUnit() 
-    { 
-        return usageUnit; 
-    }
+  public double getUsageAmount() {
+    return usageAmount;
+  }
 
-    public double getEffectiveCost() 
-    { 
-        return effectiveCost; 
-    }
+  public String getUsageUnit() {
+    return usageUnit;
+  }
 
-    public String getCurrency() 
-    { 
-        return currency; 
-    }
+  public double getEffectiveCost() {
+    return effectiveCost;
+  }
 
-    public String getPricingModel() 
-    { 
-        return pricingModel; 
-    }
+  public String getCurrency() {
+    return currency;
+  }
+
+  public String getPricingModel() {
+    return pricingModel;
+  }
 }

--- a/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/normalization/normalizers/AwsNormalizer.java
+++ b/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/normalization/normalizers/AwsNormalizer.java
@@ -2,18 +2,16 @@ package com.cloudsherpa.ingestion.normalization.normalizers;
 
 import com.cloudsherpa.ingestion.normalization.model.NormalizedMetric;
 
-public class AwsNormalizer implements Normalizer
-{
-    @Override
-    public NormalizedMetric normalize(String mockRawMetrics)
-    {
-        return new NormalizedMetric("", "", 0, 0, "", "", "", 0, "", 0, "", "");
-    }
+public class AwsNormalizer implements Normalizer {
+  @Override
+  public NormalizedMetric normalize(String mockRawMetrics) {
+    return new NormalizedMetric("", "", 0, 0, "", "", "", 0, "", 0, "", "");
+  }
 
-    private static String normalizeCategory(String category)
-    {
-        return ""; // Map the categories from the raw data to our predefined categories that we want to show the user / use
-    }
+  private static String normalizeCategory(String category) {
+    return ""; // Map the categories from the raw data to our predefined categories that we want to
+    // show the user / use
+  }
 
-    // Other normalize functions will probably also be added if we see it is necessary
+  // Other normalize functions will probably also be added if we see it is necessary
 }

--- a/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/normalization/normalizers/Normalizer.java
+++ b/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/normalization/normalizers/Normalizer.java
@@ -2,8 +2,7 @@ package com.cloudsherpa.ingestion.normalization.normalizers;
 
 import com.cloudsherpa.ingestion.normalization.model.NormalizedMetric;
 
-public interface Normalizer 
-{
-    // This will eventually be something like NormalizedMetric normalize(RawMetric raw);
-    NormalizedMetric normalize(String mockRawMetrics);
+public interface Normalizer {
+  // This will eventually be something like NormalizedMetric normalize(RawMetric raw);
+  NormalizedMetric normalize(String mockRawMetrics);
 }

--- a/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/service/CloudUsageService.java
+++ b/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/service/CloudUsageService.java
@@ -1,19 +1,17 @@
 package com.cloudsherpa.ingestion.service;
 
+import com.cloudsherpa.ingestion.normalization.model.NormalizedMetric;
 import org.springframework.stereotype.Service;
 
-import com.cloudsherpa.ingestion.normalization.model.NormalizedMetric;
-
-/**
- * Intermediary between the CloudUsageController and the ingestion pipeline.
- */
+/** Intermediary between the CloudUsageController and the ingestion pipeline. */
 @Service
 public class CloudUsageService {
 
-    // Temporary method used to test the ingestion and normalization flow.
-    public NormalizedMetric sendMockEvent() {
-        long now = System.currentTimeMillis();
-        NormalizedMetric metric = new NormalizedMetric(
+  // Temporary method used to test the ingestion and normalization flow.
+  public NormalizedMetric sendMockEvent() {
+    long now = System.currentTimeMillis();
+    NormalizedMetric metric =
+        new NormalizedMetric(
             "mock-metric-1",
             "AWS",
             now,
@@ -25,10 +23,9 @@ public class CloudUsageService {
             "Hours",
             12.75,
             "USD",
-            "OnDemand"
-        );
+            "OnDemand");
 
-        System.out.println("Ingested normalized metric: " + metric.getMetricId());
-        return metric;
-    }
+    System.out.println("Ingested normalized metric: " + metric.getMetricId());
+    return metric;
+  }
 }

--- a/apps/ingestion/src/test/java/com/cloudsherpa/ingestion/IngestionApplicationTests.java
+++ b/apps/ingestion/src/test/java/com/cloudsherpa/ingestion/IngestionApplicationTests.java
@@ -6,8 +6,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class IngestionApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
-
+  @Test
+  void contextLoads() {}
 }

--- a/apps/service/config/checkstyle/checkstyle.xml
+++ b/apps/service/config/checkstyle/checkstyle.xml
@@ -1,0 +1,487 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+    Checkstyle configuration that checks the Google coding conventions from Google Java Style
+    that can be found at https://google.github.io/styleguide/javaguide.html
+
+    Checkstyle is very configurable. Be sure to read the documentation at
+    http://checkstyle.org (or in your downloaded distribution).
+
+    To completely disable a check, just comment it out or delete it from the file.
+    To suppress certain violations please review suppression filters.
+
+    Authors: Max Vetrenko, Mauryan Kansara, Ruslan Diachenko, Roman Ivanov.
+ -->
+
+<module name="Checker">
+
+  <property name="charset" value="UTF-8"/>
+
+  <property name="severity" value="${org.checkstyle.google.severity}" default="warning"/>
+
+  <property name="fileExtensions" value="java, properties, xml"/>
+  <!-- Excludes all 'module-info.java' files              -->
+  <!-- See https://checkstyle.org/filefilters/index.html -->
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="module\-info\.java$"/>
+  </module>
+
+  <module name="SuppressWarningsFilter"/>
+
+  <!-- https://checkstyle.org/filters/suppressionfilter.html -->
+  <module name="SuppressionFilter">
+    <property name="file" value="${org.checkstyle.google.suppressionfilter.config}"
+           default="checkstyle-suppressions.xml" />
+    <property name="optional" value="true"/>
+  </module>
+
+  <!-- https://checkstyle.org/filters/suppresswithnearbytextfilter.html -->
+  <module name="SuppressWithNearbyTextFilter">
+    <property name="nearbyTextPattern"
+              value="CHECKSTYLE.SUPPRESS\: (\w+) for ([+-]\d+) lines"/>
+    <property name="checkPattern" value="$1"/>
+    <property name="lineRange" value="$2"/>
+  </module>
+
+  <!-- Checks for whitespace                               -->
+  <!-- See http://checkstyle.org/checks/whitespace/index.html -->
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+
+  <module name="LineLength">
+    <property name="fileExtensions" value="java"/>
+    <property name="max" value="100"/>
+    <property name="ignorePattern"
+             value="^package.*|^import.*|href\s*=\s*&quot;[^&quot;]*&quot;|http://|https://|ftp://"/>
+  </module>
+  <!--  Suppression to prevent LineLength Check from flagging lines in Text-blocks -->
+  <module name="SuppressWithPlainTextCommentFilter">
+    <property name="checkFormat" value="LineLength"/>
+    <property name="offCommentFormat" value='^.*"""\s*$'/>
+    <property name="onCommentFormat" value='^\s*"""\s*(?:[,;]|.+)$'/>
+  </module>
+  <module name="SuppressWithPlainTextCommentFilter">
+    <property name="checkFormat" value="IndentationCheck"/>
+    <property name="offCommentFormat" value='^""".?'/>
+    <property name="onCommentFormat" value='.'/>
+  </module>
+  <module name="TreeWalker">
+    <module name="OuterTypeFilename"/>
+    <module name="MatchXpath">
+      <property name="id" value="singleLineCommentStartWithSpace"/>
+      <property name="query"
+                value="//SINGLE_LINE_COMMENT[./COMMENT_CONTENT[not(starts-with(@text, ' '))
+                       and not(starts-with(@text, '/'))
+                       and not(@text = '\n') and not(ends-with(@text, '//\n'))]]"/>
+      <message key="matchxpath.match" value="''//'' must be followed by a whitespace."/>
+    </module>
+    <module name="IllegalTokenText">
+      <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL, TEXT_BLOCK_CONTENT"/>
+      <property name="format"
+          value="\\u00(08|09|0(a|A)|0(c|C)|0(d|D)|20|22|27|5(C|c))|\\(0(10|11|12|14|15|40|42|47)|134)"/>
+      <property name="message"
+               value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
+    </module>
+    <module name="AvoidEscapedUnicodeCharacters">
+      <property name="allowEscapesForControlCharacters" value="true"/>
+      <property name="allowByTailComment" value="true"/>
+      <property name="allowNonPrintableEscapes" value="true"/>
+    </module>
+    <module name="AvoidStarImport"/>
+    <module name="OneTopLevelClass"/>
+    <module name="NoLineWrap">
+      <property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT"/>
+    </module>
+    <module name="NeedBraces">
+      <property name="tokens"
+               value="LITERAL_DO, LITERAL_ELSE, LITERAL_FOR, LITERAL_IF, LITERAL_WHILE"/>
+    </module>
+    <module name="LeftCurly">
+      <property name="id" value="LeftCurlyEol"/>
+      <property name="tokens"
+                value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF,
+                    INTERFACE_DEF, LAMBDA, LITERAL_CATCH,
+                    LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, METHOD_DEF,
+                    OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF, SWITCH_RULE"/>
+    </module>
+    <module name="LeftCurly">
+      <property name="id" value="LeftCurlyNl"/>
+      <property name="option" value="nl"/>
+      <property name="tokens"
+                value="LITERAL_CASE, LITERAL_DEFAULT"/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <!-- LITERAL_CASE, LITERAL_DEFAULT are reused in SWITCH_RULE  -->
+      <property name="id" value="LeftCurlyNl"/>
+      <property name="query" value="//SWITCH_RULE/SLIST"/>
+    </module>
+    <module name="RightCurly">
+      <property name="id" value="RightCurlySame"/>
+      <property name="tokens"
+                value="LITERAL_TRY, LITERAL_CATCH, LITERAL_IF, LITERAL_ELSE,
+                    LITERAL_DO"/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <property name="id" value="RightCurlySame"/>
+      <property name="query" value="//RCURLY[parent::SLIST[parent::LITERAL_CATCH
+                               and not(parent::LITERAL_CATCH/following-sibling::*)]]"/>
+    </module>
+    <module name="RightCurly">
+      <property name="id" value="RightCurlyAlone"/>
+      <property name="option" value="alone"/>
+      <property name="tokens"
+               value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
+                    INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,
+                    COMPACT_CTOR_DEF, LITERAL_SWITCH, LITERAL_CASE, LITERAL_FINALLY,
+                    LITERAL_CATCH"/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <!-- suppression is required till https://github.com/checkstyle/checkstyle/issues/7541 -->
+      <property name="id" value="RightCurlyAlone"/>
+      <property name="query" value="//RCURLY[parent::SLIST[count(./*)=1
+                               and not(parent::LITERAL_CATCH)]
+                               or (preceding-sibling::*[last()][self::LCURLY]
+                               and not(parent::SLIST/parent::LITERAL_CATCH))
+                               or (parent::SLIST/parent::LITERAL_CATCH
+                               and parent::SLIST/parent::LITERAL_CATCH/following-sibling::*)]"/>
+    </module>
+    <module name="WhitespaceAfter">
+      <property name="tokens"
+               value="COMMA, SEMI, TYPECAST, ELLIPSIS, LITERAL_YIELD, LITERAL_CASE, ANNOTATIONS"/>
+    </module>
+    <module name="WhitespaceAround">
+      <property name="allowEmptyConstructors" value="true"/>
+      <property name="allowEmptyLambdas" value="true"/>
+      <property name="allowEmptyMethods" value="true"/>
+      <property name="allowEmptyTypes" value="true"/>
+      <property name="allowEmptyLoops" value="true"/>
+      <property name="allowEmptySwitchBlockStatements" value="true"/>
+      <property name="ignoreEnhancedForColon" value="false"/>
+      <property name="tokens"
+               value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR,
+                    BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND,
+                    LCURLY, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY,
+                    LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SWITCH, LITERAL_SYNCHRONIZED,
+                    LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN,
+                    NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, RCURLY, SL, SLIST, SL_ASSIGN, SR,
+                    SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT,
+                    TYPE_EXTENSION_AND, LITERAL_WHEN"/>
+      <message key="ws.notFollowed"
+              value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks
+               may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
+      <message key="ws.notPreceded"
+              value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <property name="checks" value="WhitespaceAround"/>
+      <property name="query" value="//*[self::LITERAL_IF or self::LITERAL_ELSE or
+                                 self::STATIC_INIT]/SLIST[count(./*)=1]
+                                 | //*[self::STATIC_INIT or self::LITERAL_TRY or self::LITERAL_IF]
+                                 //*[self::RCURLY][parent::SLIST[count(./*)=1]]
+                                 | //SLIST[count(./*)=1][parent::LITERAL_TRY and
+                                 not(following-sibling::*)]
+                                 | //SLIST[count(./*)=1][parent::LITERAL_CATCH and
+                                 not(parent::LITERAL_CATCH/following-sibling::*)]"/>
+    </module>
+    <module name="RegexpSinglelineJava">
+      <property name="format" value="\{[ ]+\}"/>
+      <property name="message" value="Empty blocks should have no spaces. Empty blocks
+                                   may only be represented as '{}' when not part of a
+                                   multi-block statement (4.1.3)"/>
+    </module>
+    <module name="OneStatementPerLine"/>
+    <module name="MultipleVariableDeclarations"/>
+    <module name="ArrayTypeStyle"/>
+    <!-- <module name="JavadocLeadingAsteriskAlign"/>
+    <module name="JavadocMissingLeadingAsterisk"/>
+    <module name="JavadocContentLocation"/> -->
+    <module name="MissingSwitchDefault"/>
+    <module name="FallThrough"/>
+    <module name="UpperEll"/>
+    <module name="ModifierOrder"/>
+    <module name="TextBlockGoogleStyleFormatting"/>
+    <module name="EmptyLineSeparator">
+      <property name="tokens"
+               value="PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                    STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF, RECORD_DEF,
+                    COMPACT_CTOR_DEF"/>
+      <property name="allowNoEmptyLineBetweenFields" value="true"/>
+      <property name="allowMultipleEmptyLines" value="false"/>
+    </module>
+    <module name="SeparatorWrap">
+      <property name="id" value="SeparatorWrapDot"/>
+      <property name="tokens" value="DOT"/>
+      <property name="option" value="nl"/>
+    </module>
+    <module name="SeparatorWrap">
+      <property name="id" value="SeparatorWrapComma"/>
+      <property name="tokens" value="COMMA"/>
+      <property name="option" value="EOL"/>
+    </module>
+    <module name="SeparatorWrap">
+      <!-- ELLIPSIS is EOL until https://github.com/google/styleguide/issues/259 -->
+      <property name="id" value="SeparatorWrapEllipsis"/>
+      <property name="tokens" value="ELLIPSIS"/>
+      <property name="option" value="EOL"/>
+    </module>
+    <module name="SeparatorWrap">
+      <!-- ARRAY_DECLARATOR is EOL until https://github.com/google/styleguide/issues/258 -->
+      <property name="id" value="SeparatorWrapArrayDeclarator"/>
+      <property name="tokens" value="ARRAY_DECLARATOR"/>
+      <property name="option" value="EOL"/>
+    </module>
+    <module name="SeparatorWrap">
+      <property name="id" value="SeparatorWrapMethodRef"/>
+      <property name="tokens" value="METHOD_REF"/>
+      <property name="option" value="nl"/>
+    </module>
+    <module name="PackageName">
+      <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+      <message key="name.invalidPattern"
+             value="Package name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="TypeName">
+      <property name="format" value="^[A-Z][a-zA-Z0-9]*(?:[0-9](?:_[0-9]+)*)?$"/>
+      <property name="tokens" value="CLASS_DEF"/>
+      <message key="name.invalidPattern"
+             value="Type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="TypeName">
+      <property name="tokens" value="INTERFACE_DEF, ENUM_DEF,
+                    ANNOTATION_DEF, RECORD_DEF"/>
+      <message key="name.invalidPattern"
+             value="Type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="GoogleNonConstantFieldName"/>
+    <module name="ParameterName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+             value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="LambdaParameterName">
+      <property name="format" value="^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$"/>
+      <message key="name.invalidPattern"
+             value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="CatchParameterName">
+      <property name="format" value="^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$"/>
+      <message key="name.invalidPattern"
+             value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="LocalVariableName">
+      <property name="format" value="^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$"/>
+      <message key="name.invalidPattern"
+             value="Local variable name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="PatternVariableName">
+      <property name="format" value="^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$"/>
+      <message key="name.invalidPattern"
+             value="Pattern variable name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="ClassTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+             value="Class type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="RecordComponentName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+               value="Record component name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="RecordTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+               value="Record type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="MethodTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+             value="Method type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="InterfaceTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+             value="Interface type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="NoFinalizer"/>
+    <module name="GenericWhitespace">
+      <message key="ws.followed"
+             value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+      <message key="ws.preceded"
+             value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+      <message key="ws.illegalFollow"
+             value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+      <message key="ws.notPreceded"
+             value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+    </module>
+    <module name="Indentation">
+      <property name="basicOffset" value="2"/>
+      <property name="braceAdjustment" value="2"/>
+      <property name="caseIndent" value="2"/>
+      <property name="throwsIndent" value="4"/>
+      <property name="lineWrappingIndentation" value="4"/>
+      <property name="arrayInitIndent" value="2"/>
+    </module>
+
+    <module name="AbbreviationAsWordInName">
+      <property name="ignoreFinal" value="false"/>
+      <property name="allowedAbbreviationLength" value="0"/>
+      <property name="tokens"
+               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,
+                    PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF,
+                    RECORD_COMPONENT_DEF"/>
+    </module>
+    <module name="NoWhitespaceBeforeCaseDefaultColon"/>
+    <module name="OverloadMethodsDeclarationOrder"/>
+    <module name="ConstructorsDeclarationGrouping"/>
+    <module name="VariableDeclarationUsageDistance"/>
+    <module name="CustomImportOrder">
+      <property name="sortImportsInGroupAlphabetically" value="true"/>
+      <property name="separateLineBetweenGroups" value="true"/>
+      <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
+    </module>
+    <module name="MethodParamPad">
+      <property name="tokens"
+               value="CTOR_DEF, LITERAL_NEW, METHOD_CALL, METHOD_DEF, CTOR_CALL,
+                    SUPER_CTOR_CALL, ENUM_CONSTANT_DEF, RECORD_DEF, RECORD_PATTERN_DEF"/>
+    </module>
+    <module name="NoWhitespaceBefore">
+      <property name="tokens"
+               value="COMMA, SEMI, POST_INC, POST_DEC, DOT,
+                    LABELED_STAT, METHOD_REF, ELLIPSIS"/>
+      <property name="allowLineBreaks" value="true"/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <property name="checks" value="NoWhitespaceBefore"/>
+      <property name="query"
+          value="//ELLIPSIS[preceding-sibling::TYPE/ANNOTATIONS[ANNOTATION[LPAREN]
+              or not(following-sibling::*)]]"/>
+    </module>
+    <module name="ParenPad">
+      <property name="tokens"
+               value="ANNOTATION, ANNOTATION_FIELD_DEF, CTOR_CALL, CTOR_DEF, DOT, ENUM_CONSTANT_DEF,
+                    EXPR, LITERAL_CATCH, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_NEW,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_WHILE, METHOD_CALL,
+                    METHOD_DEF, QUESTION, RESOURCE_SPECIFICATION, SUPER_CTOR_CALL, LAMBDA,
+                    RECORD_DEF, RECORD_PATTERN_DEF"/>
+    </module>
+    <module name="OperatorWrap">
+      <property name="option" value="NL"/>
+      <property name="tokens"
+               value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR,
+                    LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF,
+                    TYPE_EXTENSION_AND "/>
+    </module>
+    <module name="AnnotationLocation">
+      <property name="id" value="AnnotationLocationTypeAndPackage"/>
+      <property name="tokens"
+               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, RECORD_DEF, PACKAGE_DEF"/>
+      <property name="allowSamelineSingleParameterlessAnnotation" value="false"/>
+    </module>
+    <module name="AnnotationLocation">
+      <property name="id" value="AnnotationLocationMethodsAndCtors"/>
+      <property name="tokens"
+               value="METHOD_DEF, CTOR_DEF, COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="AnnotationLocation">
+      <property name="id" value="AnnotationLocationVariables"/>
+      <property name="tokens" value="VARIABLE_DEF"/>
+      <property name="allowSamelineMultipleAnnotations" value="true"/>
+    </module>
+    <module name="MissingOverrideOnRecordAccessor"/>
+    <module name="NonEmptyAtclauseDescription"/>
+    <!-- <module name="InvalidJavadocPosition"/> -->
+    <!-- <module name="JavadocTagContinuationIndentation"/>
+    <module name="SummaryJavadoc">
+      <property name="forbiddenSummaryFragments"
+        value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )|^[a-z]"/>
+    </module>
+    <module name="JavadocParagraph">
+      <property name="allowNewlineParagraph" value="false"/>
+    </module> -->
+    <module name="RequireEmptyLineBeforeBlockTagGroup"/>
+    <module name="AtclauseOrder">
+      <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
+      <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF,
+                                  VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF"/>
+    </module>
+    <!-- <module name="JavadocMethod">
+      <property name="accessModifiers" value="public"/>
+      <property name="allowMissingParamTags" value="true"/>
+      <property name="allowMissingReturnTag" value="true"/>
+      <property name="allowedAnnotations" value="Override, Test"/>
+      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF"/>
+    </module> -->
+    <!-- <module name="MissingJavadocMethod">
+      <property name="scope" value="protected"/>
+      <property name="allowMissingPropertyJavadoc" value="true"/>
+      <property name="allowedAnnotations" value="Override, Test"/>
+      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF,
+                                   COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <property name="checks" value="MissingJavadocMethod"/>
+      <property name="query" value="//*[self::METHOD_DEF or self::CTOR_DEF
+                                 or self::ANNOTATION_FIELD_DEF or self::COMPACT_CTOR_DEF]
+                                 [ancestor::*[self::INTERFACE_DEF or self::CLASS_DEF
+                                 or self::RECORD_DEF or self::ENUM_DEF]
+                                 [not(./MODIFIERS/LITERAL_PUBLIC)]]"/>
+    </module>
+    <module name="MissingJavadocType">
+      <property name="scope" value="protected"/>
+      <property name="tokens"
+                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                      RECORD_DEF, ANNOTATION_DEF"/>
+      <property name="excludeScope" value="nothing"/>
+    </module> -->
+    <module name="MethodName">
+      <property name="format"
+          value="^(?![a-z]$)(?![a-z][A-Z])[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*(?:_[0-9]+)*$"/>
+      <message key="name.invalidPattern"
+             value="Method name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <property name="checks" value="MethodName"/>
+      <property name="query" value="//METHOD_DEF[
+                                     ./MODIFIERS/ANNOTATION//IDENT[contains(@text, 'Test')]
+                                   ]/IDENT"/>
+      <property name="message" value="'[a-z][a-z0-9][a-zA-Z0-9]*(?:_[a-z][a-z0-9][a-zA-Z0-9]*)*'"/>
+    </module>
+    <!-- <module name="SingleLineJavadoc"/> -->
+    <module name="TodoComment">
+      <property name="format" value="^[ \t]*(?!TODO:)(?i:TODO)\b:?"/>
+      <message key="todo.match"
+               value="''TODO:'' must be written in all caps and followed by a colon."/>
+    </module>
+    <module name="EmptyCatchBlock">
+      <property name="commentFormat" value="\w+"/>
+    </module>
+    <module name="CommentsIndentation">
+      <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN"/>
+    </module>
+    <!-- https://checkstyle.org/filters/suppressionxpathfilter.html -->
+    <module name="SuppressionXpathFilter">
+      <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"
+             default="checkstyle-xpath-suppressions.xml" />
+      <property name="optional" value="true"/>
+    </module>
+    <module name="SuppressWarningsHolder" />
+    <module name="SuppressionCommentFilter">
+      <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)" />
+      <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)" />
+      <property name="checkFormat" value="$1" />
+    </module>
+    <module name="SuppressWithNearbyCommentFilter">
+      <property name="commentFormat" value="CHECKSTYLE.SUPPRESS\: ([\w\|]+)"/>
+      <!-- $1 refers to the first match group in the regex defined in commentFormat -->
+      <property name="checkFormat" value="$1"/>
+      <!-- The check is suppressed in the next line of code after the comment -->
+      <property name="influenceFormat" value="1"/>
+    </module>
+  </module>
+</module>

--- a/apps/service/pom.xml
+++ b/apps/service/pom.xml
@@ -1,30 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.5.7</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.cloudsherpa</groupId>
 	<artifactId>service</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>service</name>
-	<description/>
-	<url/>
+	<description />
+	<url />
 	<licenses>
-		<license/>
+		<license />
 	</licenses>
 	<developers>
-		<developer/>
+		<developer />
 	</developers>
 	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
+		<connection />
+		<developerConnection />
+		<tag />
+		<url />
 	</scm>
 	<properties>
 		<java.version>21</java.version>
@@ -65,6 +66,54 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>3.6.0</version>
+				<dependencies>
+					<dependency>
+						<groupId>com.puppycrawl.tools</groupId>
+						<artifactId>checkstyle</artifactId>
+						<version>13.4.2</version>
+					</dependency>
+				</dependencies>
+				<configuration>
+					<configLocation>config/checkstyle/checkstyle.xml</configLocation>
+					<consoleOutput>true</consoleOutput>
+					<failsOnError>true</failsOnError>
+					<linkXRef>false</linkXRef>
+				</configuration>
+				<executions>
+					<execution>
+						<id>validate</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>com.diffplug.spotless</groupId>
+				<artifactId>spotless-maven-plugin</artifactId>
+				<version>2.43.0</version>
+
+				<configuration>
+					<java>
+						<googleJavaFormat>
+							<version>1.17.0</version>
+						</googleJavaFormat>
+					</java>
+				</configuration>
+
+				<executions>
+					<execution>
+						<goals>
+							<goal>apply</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/apps/service/src/main/java/com/cloudsherpa/service/ServiceApplication.java
+++ b/apps/service/src/main/java/com/cloudsherpa/service/ServiceApplication.java
@@ -6,8 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class ServiceApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(ServiceApplication.class, args);
-	}
-
+  public static void main(String[] args) {
+    SpringApplication.run(ServiceApplication.class, args);
+  }
 }

--- a/apps/service/src/main/java/com/cloudsherpa/service/analytics/controller/AnalyticsController.java
+++ b/apps/service/src/main/java/com/cloudsherpa/service/analytics/controller/AnalyticsController.java
@@ -1,57 +1,60 @@
 package com.cloudsherpa.service.analytics.controller;
 
+import com.cloudsherpa.service.analytics.dto.MetricDTO;
 import com.cloudsherpa.service.analytics.entity.NormalizedMetrics;
 import com.cloudsherpa.service.analytics.service.AnalyticsPersistenceService;
-import com.cloudsherpa.service.analytics.dto.MetricDTO;
-
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import java.time.OffsetDateTime;
+import java.util.List;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-
-import java.time.OffsetDateTime;
-import java.util.List;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/analytics")
-public class AnalyticsController 
-{
-    // ! Currently only using 1 way of getting data (/metrics) because we only have 1 normalized_metrics table
-    // ! We might want to change this such that the normalized_metrics table is split into 2 tables (1 for billing and 1 for usage)
+public class AnalyticsController {
+  // ! Currently only using 1 way of getting data (/metrics) because we only have 1
+  // normalized_metrics table
+  // ! We might want to change this such that the normalized_metrics table is split into 2 tables (1
+  // for billing and 1 for usage)
 
-    // ! We also currently have no way of initializing the foreign key environment_id in the environment_reference table
-    // ! Will look into how we can do that
+  // ! We also currently have no way of initializing the foreign key environment_id in the
+  // environment_reference table
+  // ! Will look into how we can do that
 
-    private AnalyticsPersistenceService analyticsPersistenceService;
+  private AnalyticsPersistenceService analyticsPersistenceService;
 
-    public AnalyticsController(AnalyticsPersistenceService analyticsPersistenceService) 
-    {
-        this.analyticsPersistenceService = analyticsPersistenceService;
-    }
+  public AnalyticsController(AnalyticsPersistenceService analyticsPersistenceService) {
+    this.analyticsPersistenceService = analyticsPersistenceService;
+  }
 
-    // POST request to insert a record into the database
-    // Insert into the AnalyticsDB
-    @PostMapping("/metrics/record") // URL: /api/analytics/metrics/record
-    public String recordMetric(@RequestBody MetricDTO request) 
-    {
-        analyticsPersistenceService.recordMetric(request.getEnvironmentId(), request.getResourceId(), request.getServiceCategory(),
-            request.getUsageAmount(), request.getUsageUnit(), request.getCostAmount(), request.getCurrency()
-        );
-        
-        return "Metric recorded successfully";
-    }
+  // POST request to insert a record into the database
+  // Insert into the AnalyticsDB
+  @PostMapping("/metrics/record") // URL: /api/analytics/metrics/record
+  public String recordMetric(@RequestBody MetricDTO request) {
+    analyticsPersistenceService.recordMetric(
+        request.getEnvironmentId(),
+        request.getResourceId(),
+        request.getServiceCategory(),
+        request.getUsageAmount(),
+        request.getUsageUnit(),
+        request.getCostAmount(),
+        request.getCurrency());
 
-    // GET request to retrieve data
-    // Using List because this function will return multiple records
-    // Spring automatically serializes the list into a JSON array
-    @GetMapping("/metrics/window") // URL: /api/analytics/metrics/window
-    public List<NormalizedMetrics> getMetricsByTimeWindow(
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime startTime, //ISO is standard date/time format
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime endTime) 
-    {
-        return analyticsPersistenceService.getMetricsInTimeWindow(startTime, endTime);
-    }
+    return "Metric recorded successfully";
+  }
+
+  // GET request to retrieve data
+  // Using List because this function will return multiple records
+  // Spring automatically serializes the list into a JSON array
+  @GetMapping("/metrics/window") // URL: /api/analytics/metrics/window
+  public List<NormalizedMetrics> getMetricsByTimeWindow(
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          OffsetDateTime startTime, // ISO is standard date/time format
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime endTime) {
+    return analyticsPersistenceService.getMetricsInTimeWindow(startTime, endTime);
+  }
 }

--- a/apps/service/src/main/java/com/cloudsherpa/service/analytics/dto/MetricDTO.java
+++ b/apps/service/src/main/java/com/cloudsherpa/service/analytics/dto/MetricDTO.java
@@ -2,56 +2,45 @@ package com.cloudsherpa.service.analytics.dto;
 
 import java.math.BigDecimal;
 import java.util.UUID;
-import java.time.OffsetDateTime;
-import java.util.List;
 
-public class MetricDTO 
-{
-    private UUID environmentId;
-    private String resourceId;
-    private String serviceCategory;
-    private BigDecimal usageAmount;
-    private String usageUnit;
-    private BigDecimal costAmount;
-    private String currency = "ZAR";
+public class MetricDTO {
+  private UUID environmentId;
+  private String resourceId;
+  private String serviceCategory;
+  private BigDecimal usageAmount;
+  private String usageUnit;
+  private BigDecimal costAmount;
+  private String currency = "ZAR";
 
-    public MetricDTO()
-    {
-        // Standard empty constructor 
-    }
+  public MetricDTO() {
+    // Standard empty constructor
+  }
 
-    public UUID getEnvironmentId() 
-    {
-        return environmentId;
-    }
+  public UUID getEnvironmentId() {
+    return environmentId;
+  }
 
-    public String getResourceId() 
-    {
-        return resourceId;
-    }
+  public String getResourceId() {
+    return resourceId;
+  }
 
-    public String getServiceCategory() 
-    {
-        return serviceCategory;
-    }
+  public String getServiceCategory() {
+    return serviceCategory;
+  }
 
-    public BigDecimal getUsageAmount() 
-    {
-        return usageAmount;
-    }
+  public BigDecimal getUsageAmount() {
+    return usageAmount;
+  }
 
-    public String getUsageUnit() 
-    {
-        return usageUnit;
-    }
+  public String getUsageUnit() {
+    return usageUnit;
+  }
 
-    public BigDecimal getCostAmount() 
-    {
-        return costAmount;
-    }
+  public BigDecimal getCostAmount() {
+    return costAmount;
+  }
 
-    public String getCurrency() 
-    {
-        return currency;
-    }
+  public String getCurrency() {
+    return currency;
+  }
 }

--- a/apps/service/src/main/java/com/cloudsherpa/service/analytics/entity/EnvironmentReference.java
+++ b/apps/service/src/main/java/com/cloudsherpa/service/analytics/entity/EnvironmentReference.java
@@ -1,61 +1,53 @@
-// Used https://jakarta.ee/learn/docs/jakartaee-tutorial/current/persist/persistence-intro/persistence-intro.html for assistance
+// Used
+// https://jakarta.ee/learn/docs/jakartaee-tutorial/current/persist/persistence-intro/persistence-intro.html for assistance
 
 package com.cloudsherpa.service.analytics.entity;
 
-import jakarta.persistence.Table;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
-
-import java.time.OffsetDateTime;
-
-import java.util.UUID;
 import jakarta.persistence.Id;
-
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import java.util.UUID;
 
 @Entity
 // Table name is the same as the environment_reference table in analytics-schema.sql
-@Table(name = "environment_reference") 
-public class EnvironmentReference 
-{
-    // The following variables are directly mapped to column names in the environment_reference table in analytics-schema.sql
-    // Automatically generates a UUID for each record
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "environment_id", nullable = false, updatable = false)
-    private UUID environmentId;
+@Table(name = "environment_reference")
+public class EnvironmentReference {
+  // The following variables are directly mapped to column names in the environment_reference table
+  // in analytics-schema.sql
+  // Automatically generates a UUID for each record
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(name = "environment_id", nullable = false, updatable = false)
+  private UUID environmentId;
 
-    @Column(name = "provider", nullable = false, length = 50)
-    private String provider;
+  @Column(name = "provider", nullable = false, length = 50)
+  private String provider;
 
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private OffsetDateTime createdAt;
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private OffsetDateTime createdAt;
 
-    public EnvironmentReference() 
-    {
-        // required by JPA to have a no-argument default constructor
-    }
+  public EnvironmentReference() {
+    // required by JPA to have a no-argument default constructor
+  }
 
-    public EnvironmentReference(String provider, OffsetDateTime createdAt) 
-    {
-        this.provider = provider;
-        this.createdAt = createdAt;
-    }
+  public EnvironmentReference(String provider, OffsetDateTime createdAt) {
+    this.provider = provider;
+    this.createdAt = createdAt;
+  }
 
-    public UUID getEnvironmentId() 
-    {
-        return environmentId;
-    }
+  public UUID getEnvironmentId() {
+    return environmentId;
+  }
 
-    public String getProvider() 
-    {
-        return provider;
-    }
+  public String getProvider() {
+    return provider;
+  }
 
-    public OffsetDateTime getCreatedAt() 
-    {
-        return createdAt;
-    }
+  public OffsetDateTime getCreatedAt() {
+    return createdAt;
+  }
 }

--- a/apps/service/src/main/java/com/cloudsherpa/service/analytics/entity/NormalizedMetrics.java
+++ b/apps/service/src/main/java/com/cloudsherpa/service/analytics/entity/NormalizedMetrics.java
@@ -1,121 +1,113 @@
-// Refer to EnvironmentReference.java for most of the documentation 
+// Refer to EnvironmentReference.java for most of the documentation
 // and explanations on what I am doing here
 package com.cloudsherpa.service.analytics.entity;
 
-import jakarta.persistence.Table;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
-
-import java.math.BigDecimal;
-import java.time.OffsetDateTime;
-
-import java.util.UUID;
 import jakarta.persistence.Id;
-
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.UUID;
 
 @Entity
 @Table(name = "normalized_metrics")
-public class NormalizedMetrics 
-{
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "metric_id", nullable = false, updatable = false)
-    private UUID metricId;
+public class NormalizedMetrics {
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(name = "metric_id", nullable = false, updatable = false)
+  private UUID metricId;
 
-    @Column(name = "recorded_at", nullable = false, updatable = false)
-    private OffsetDateTime recordedAt;
+  @Column(name = "recorded_at", nullable = false, updatable = false)
+  private OffsetDateTime recordedAt;
 
-    // This is the foreign key mapping to environment_reference table
-    // Many-to-one because: One AWS environment will have multiple of individual metric records associated with it.
-    @ManyToOne(optional = false)
-    @JoinColumn(name = "environment_id", nullable = false)
-    private EnvironmentReference environmentReference;
+  // This is the foreign key mapping to environment_reference table
+  // Many-to-one because: One AWS environment will have multiple of individual metric records
+  // associated with it.
+  @ManyToOne(optional = false)
+  @JoinColumn(name = "environment_id", nullable = false)
+  private EnvironmentReference environmentReference;
 
-    @Column(name = "resource_id", nullable = false, length = 255)
-    private String resourceId;
+  @Column(name = "resource_id", nullable = false, length = 255)
+  private String resourceId;
 
-    @Column(name = "service_category", nullable = false, length = 100)
-    private String serviceCategory;
+  @Column(name = "service_category", nullable = false, length = 100)
+  private String serviceCategory;
 
-    @Column(name = "usage_unit", nullable = false, length = 50)
-    private String usageUnit;
+  @Column(name = "usage_unit", nullable = false, length = 50)
+  private String usageUnit;
 
-    @Column(name = "currency", length = 10, nullable = false)
-    private String currency;
+  @Column(name = "currency", length = 10, nullable = false)
+  private String currency;
 
-    // Use BigDecimal when working with financial data or measurement data
-    // This is for better accuracy
-    @Column(name = "usage_amount", nullable = false, precision = 19, scale = 6)
-    private BigDecimal usageAmount;
+  // Use BigDecimal when working with financial data or measurement data
+  // This is for better accuracy
+  @Column(name = "usage_amount", nullable = false, precision = 19, scale = 6)
+  private BigDecimal usageAmount;
 
-    @Column(name = "cost_amount", nullable = false, precision = 19, scale = 6)
-    private BigDecimal costAmount;
+  @Column(name = "cost_amount", nullable = false, precision = 19, scale = 6)
+  private BigDecimal costAmount;
 
-    public NormalizedMetrics() 
-    {
-        // Default constructor
-    }
+  public NormalizedMetrics() {
+    // Default constructor
+  }
 
-    public NormalizedMetrics(OffsetDateTime recordedAt, EnvironmentReference environmentReference, 
-                            String resourceId, String serviceCategory, BigDecimal usageAmount, 
-                             String usageUnit, BigDecimal costAmount, String currency) 
-    {
-        this.recordedAt = recordedAt;
-        this.environmentReference = environmentReference;
-        this.resourceId = resourceId;
-        this.serviceCategory = serviceCategory;
-        this.usageAmount = usageAmount;
-        this.usageUnit = usageUnit;
-        this.costAmount = costAmount;
-        this.currency = currency;
-    }
+  public NormalizedMetrics(
+      OffsetDateTime recordedAt,
+      EnvironmentReference environmentReference,
+      String resourceId,
+      String serviceCategory,
+      BigDecimal usageAmount,
+      String usageUnit,
+      BigDecimal costAmount,
+      String currency) {
+    this.recordedAt = recordedAt;
+    this.environmentReference = environmentReference;
+    this.resourceId = resourceId;
+    this.serviceCategory = serviceCategory;
+    this.usageAmount = usageAmount;
+    this.usageUnit = usageUnit;
+    this.costAmount = costAmount;
+    this.currency = currency;
+  }
 
-    public UUID getMetricId()
-    { 
-        return metricId; 
-    }
-    
-    public OffsetDateTime getRecordedAt() 
-    { 
-        return recordedAt; 
-    }
-    
-    public EnvironmentReference getEnvironmentReference() 
-    { 
-        return environmentReference; 
-    }
-    
-    public String getResourceId() 
-    { 
-        return resourceId; 
-    }
-    
-    public String getServiceCategory() 
-    { 
-        return serviceCategory; 
-    }
-    
-    public String getUsageUnit() 
-    { 
-        return usageUnit; 
-    }
-    
-    public String getCurrency() 
-    { 
-        return currency; 
-    }
-    
-    public BigDecimal getUsageAmount() 
-    { 
-        return usageAmount; 
-    }
-    
-    public BigDecimal getCostAmount() 
-    { 
-        return costAmount; 
-    }
+  public UUID getMetricId() {
+    return metricId;
+  }
+
+  public OffsetDateTime getRecordedAt() {
+    return recordedAt;
+  }
+
+  public EnvironmentReference getEnvironmentReference() {
+    return environmentReference;
+  }
+
+  public String getResourceId() {
+    return resourceId;
+  }
+
+  public String getServiceCategory() {
+    return serviceCategory;
+  }
+
+  public String getUsageUnit() {
+    return usageUnit;
+  }
+
+  public String getCurrency() {
+    return currency;
+  }
+
+  public BigDecimal getUsageAmount() {
+    return usageAmount;
+  }
+
+  public BigDecimal getCostAmount() {
+    return costAmount;
+  }
 }

--- a/apps/service/src/main/java/com/cloudsherpa/service/analytics/repository/EnvironmentReferenceRepository.java
+++ b/apps/service/src/main/java/com/cloudsherpa/service/analytics/repository/EnvironmentReferenceRepository.java
@@ -1,12 +1,11 @@
 package com.cloudsherpa.service.analytics.repository;
 
 import com.cloudsherpa.service.analytics.entity.EnvironmentReference;
-import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 // Needs to know which table it is managing and what the datatype is for its id field
-public interface EnvironmentReferenceRepository extends JpaRepository<EnvironmentReference, UUID> 
-{
-    // Interface instantly inherits dozens of pre-written database commands
-    // Can also add custom queries using method naming (optional)
+public interface EnvironmentReferenceRepository extends JpaRepository<EnvironmentReference, UUID> {
+  // Interface instantly inherits dozens of pre-written database commands
+  // Can also add custom queries using method naming (optional)
 }

--- a/apps/service/src/main/java/com/cloudsherpa/service/analytics/repository/NormalizedMetricsRepository.java
+++ b/apps/service/src/main/java/com/cloudsherpa/service/analytics/repository/NormalizedMetricsRepository.java
@@ -3,15 +3,13 @@
 package com.cloudsherpa.service.analytics.repository;
 
 import com.cloudsherpa.service.analytics.entity.NormalizedMetrics;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.OffsetDateTime;
-import java.util.UUID;
-import java.util.List;
-
-public interface NormalizedMetricsRepository extends JpaRepository<NormalizedMetrics, UUID> 
-{
-    // Spring translates this method name into:
-    // SELECT * FROM normalized_metrics WHERE recorded_at BETWEEN ? AND ?
-    List<NormalizedMetrics> findByRecordedAtBetween(OffsetDateTime startTime, OffsetDateTime endTime);
+public interface NormalizedMetricsRepository extends JpaRepository<NormalizedMetrics, UUID> {
+  // Spring translates this method name into:
+  // SELECT * FROM normalized_metrics WHERE recorded_at BETWEEN ? AND ?
+  List<NormalizedMetrics> findByRecordedAtBetween(OffsetDateTime startTime, OffsetDateTime endTime);
 }

--- a/apps/service/src/main/java/com/cloudsherpa/service/analytics/service/AnalyticsPersistenceService.java
+++ b/apps/service/src/main/java/com/cloudsherpa/service/analytics/service/AnalyticsPersistenceService.java
@@ -1,56 +1,65 @@
-// The service class contains the business logic and uses the repository to perform 
+// The service class contains the business logic and uses the repository to perform
 // operations on the database.
-// Used https://medium.com/@bshiramagond/jpa-with-spring-boot-a-comprehensive-guide-with-examples-e07da6f3d385 for EnvironmentReferenceRepository
+// Used
+// https://medium.com/@bshiramagond/jpa-with-spring-boot-a-comprehensive-guide-with-examples-e07da6f3d385 for EnvironmentReferenceRepository
 
 package com.cloudsherpa.service.analytics.service;
 
 import com.cloudsherpa.service.analytics.entity.EnvironmentReference;
 import com.cloudsherpa.service.analytics.entity.NormalizedMetrics;
-
 import com.cloudsherpa.service.analytics.repository.EnvironmentReferenceRepository;
 import com.cloudsherpa.service.analytics.repository.NormalizedMetricsRepository;
-
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.math.BigDecimal;
-import java.time.OffsetDateTime;
-import java.util.UUID;
-import java.util.List;
-
 @Service
-public class AnalyticsPersistenceService 
-{
-    // Dependency Injection
-    @Autowired
-    private EnvironmentReferenceRepository environmentRepo;
+public class AnalyticsPersistenceService {
+  // Dependency Injection
+  @Autowired private EnvironmentReferenceRepository environmentRepo;
 
-    @Autowired
-    private NormalizedMetricsRepository metricsRepo;
+  @Autowired private NormalizedMetricsRepository metricsRepo;
 
-    // Use @Transactional when we are modifying a database in more than 1 place
-    // So that if 1 step succeeds and the other one fails, the data doesn't end up half-written
-    @Transactional
-    public void recordMetric(UUID environmentId, String resourceId, String serviceCategory, BigDecimal usageAmount, String usageUnit, BigDecimal costAmount, String currency) 
-    {
-        EnvironmentReference environment = environmentRepo.getReferenceById(environmentId);
-        NormalizedMetrics newMetric = new NormalizedMetrics(OffsetDateTime.now(), environment, resourceId, serviceCategory, usageAmount, usageUnit, costAmount, currency);
+  // Use @Transactional when we are modifying a database in more than 1 place
+  // So that if 1 step succeeds and the other one fails, the data doesn't end up half-written
+  @Transactional
+  public void recordMetric(
+      UUID environmentId,
+      String resourceId,
+      String serviceCategory,
+      BigDecimal usageAmount,
+      String usageUnit,
+      BigDecimal costAmount,
+      String currency) {
+    EnvironmentReference environment = environmentRepo.getReferenceById(environmentId);
+    NormalizedMetrics newMetric =
+        new NormalizedMetrics(
+            OffsetDateTime.now(),
+            environment,
+            resourceId,
+            serviceCategory,
+            usageAmount,
+            usageUnit,
+            costAmount,
+            currency);
 
-        // SQL insert statement
-        metricsRepo.save(newMetric);
-    }
+    // SQL insert statement
+    metricsRepo.save(newMetric);
+  }
 
-    
-    //Fetches all metrics recorded between the specified start and end times.
-    public List<NormalizedMetrics> getMetricsInTimeWindow(OffsetDateTime startTime, OffsetDateTime endTime) 
-    {
-        List<NormalizedMetrics> metrics = metricsRepo.findByRecordedAtBetween(startTime, endTime);
-        
-        // Note: Because we are fetching a List of objects, we can easily perform additional 
-        // business logic right here in Java using Streams (e.g., calculating total costs) 
-        // without needing to write complex SQL aggregation scripts.
-        
-        return metrics;
-    }
+  // Fetches all metrics recorded between the specified start and end times.
+  public List<NormalizedMetrics> getMetricsInTimeWindow(
+      OffsetDateTime startTime, OffsetDateTime endTime) {
+    List<NormalizedMetrics> metrics = metricsRepo.findByRecordedAtBetween(startTime, endTime);
+
+    // Note: Because we are fetching a List of objects, we can easily perform additional
+    // business logic right here in Java using Streams (e.g., calculating total costs)
+    // without needing to write complex SQL aggregation scripts.
+
+    return metrics;
+  }
 }

--- a/apps/service/src/test/java/com/cloudsherpa/service/ServiceApplicationTests.java
+++ b/apps/service/src/test/java/com/cloudsherpa/service/ServiceApplicationTests.java
@@ -6,8 +6,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class ServiceApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
-
+  @Test
+  void contextLoads() {}
 }


### PR DESCRIPTION
Java format linting commands:
```sh
cd apps/<spring-boot-app>
# Check for violations
./mvnw checkstyle:check
# Apply automated fixes
./mvnw spotless:apply
```
Important note: I ran        `./mvnw spotless:apply` on both the `ingestion` and `service` apps. That changed the formatting of many lines of code. I can revert those changes, I just thought it would need to happen anyway and then you can see how your code looks like.

The `spotless` plugin formats files according to the Google Java Format. I used that for `checkstyle` as well, so changes made by `spotless` should hopefully satisfy `checkstyle` rules. I just customized our checkstyle configuration to not see an absence of javadocs as a violation by commenting out those configuration lines.

Please let me know whether you think this is necessary or not. Note that builds will currently fail if there are`checkstyle`  errors, they succeed even if there are warnings though.