### PR TITLE
Spring boot apps initial CI

### DIFF
--- a/.github/workflows/ingestion-ci.yml
+++ b/.github/workflows/ingestion-ci.yml
@@ -1,0 +1,46 @@
+name: Ingestion CI
+
+on:
+    pull_request:
+        branches:
+            - dev
+            - main
+        paths:
+          - apps/ingestion/**
+          - .github/workflows/ingestion-ci.yml
+jobs:
+    ingestion-validation:
+        runs-on: ubuntu-latest
+        defaults:
+            run:
+                working-directory: apps/ingestion
+        steps:
+            - name: Checkout Repo
+              uses: actions/checkout@v5
+            
+            - name: Set up JDK
+              uses: actions/setup-java@v5
+              with:
+                distribution: 'temurin'
+                java-version: 21
+            
+            - name: Cache Maven Packages
+              uses: actions/cache@v5
+              # Keys: If dependencies change, load old cache, maven only downloads missing/changed deps
+              with:
+                path: ~/.m2/repository
+                key: ${{ runner.os }}-maven-${{ hashFiles('pom.xml') }}
+                restore-keys: ${{ runner.os }}-maven
+            
+            - name: Make Maven Wrapper Executable
+              run: chmod +x mvnw
+              
+            - name: Lint
+              run: ./mvnw checkstyle:check
+            
+            # Skip tests here but run them in next step for improved fault localization
+            - name: Build
+              run: ./mvnw clean package -DskipTests
+            
+            - name: Unit Tests
+              run: ./mvnw test

--- a/.github/workflows/service-ci.yml
+++ b/.github/workflows/service-ci.yml
@@ -1,0 +1,47 @@
+name: Service CI
+
+on:
+    pull_request:
+        branches:
+            - dev
+            - main
+        paths:
+          - apps/service/**
+          - .github/workflows/service-ci.yml
+jobs:
+    ingestion-validation:
+        runs-on: ubuntu-latest
+        defaults:
+            run:
+                working-directory: apps/service
+        steps:
+            - name: Checkout Repo
+              uses: actions/checkout@v5
+            
+            - name: Set up JDK
+              uses: actions/setup-java@v5
+              with:
+                distribution: 'temurin'
+                java-version: 21
+            
+            - name: Cache Maven Packages
+              uses: actions/cache@v5
+              # Keys: If dependencies change, load old cache, maven only downloads missing/changed deps
+              with:
+                path: ~/.m2/repository
+                key: ${{ runner.os }}-maven-${{ hashFiles('pom.xml') }}
+                restore-keys: ${{ runner.os }}-maven
+            
+            - name: Make Maven Wrapper Executable
+              run: chmod +x mvnw
+              
+            - name: Lint
+              run: ./mvnw checkstyle:check
+            
+            # Skip tests here but run them in next step for improved fault localization, i.e. we
+            # know easily if it was the build or tests that failed.
+            - name: Build
+              run: ./mvnw clean package -DskipTests
+            
+            - name: Unit Tests
+              run: ./mvnw test

--- a/.github/workflows/service-ci.yml
+++ b/.github/workflows/service-ci.yml
@@ -9,7 +9,7 @@ on:
           - apps/service/**
           - .github/workflows/service-ci.yml
 jobs:
-    ingestion-validation:
+    service-validation:
         runs-on: ubuntu-latest
         defaults:
             run:

--- a/apps/ingestion/src/test/java/com/cloudsherpa/ingestion/unit/IngestionApplicationTests.java
+++ b/apps/ingestion/src/test/java/com/cloudsherpa/ingestion/unit/IngestionApplicationTests.java
@@ -1,11 +1,8 @@
-package com.cloudsherpa.ingestion;
+package com.cloudsherpa.ingestion.unit;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class IngestionApplicationTests {
-
-  @Test
-  void contextLoads() {}
 }

--- a/apps/service/src/test/java/com/cloudsherpa/service/unit/ServiceApplicationTests.java
+++ b/apps/service/src/test/java/com/cloudsherpa/service/unit/ServiceApplicationTests.java
@@ -1,11 +1,8 @@
-package com.cloudsherpa.service;
+package com.cloudsherpa.service.unit;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class ServiceApplicationTests {
-
-  @Test
-  void contextLoads() {}
 }


### PR DESCRIPTION
Closes #181 

Basic pipelines with lint, build, test. Cache maven dependencies for performance. 

Moved stub tests to unit folder.