### PR TITLE
Metric type and store definitions

### DIFF
--- a/apps/dashboard/package-lock.json
+++ b/apps/dashboard/package-lock.json
@@ -17,7 +17,8 @@
         "react-dom": "19.2.4",
         "shadcn": "^4.6.0",
         "tailwind-merge": "^3.5.0",
-        "tw-animate-css": "^1.4.0"
+        "tw-animate-css": "^1.4.0",
+        "zustand": "^5.0.13"
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
@@ -13033,6 +13034,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
+      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -21,7 +21,8 @@
     "react-dom": "19.2.4",
     "shadcn": "^4.6.0",
     "tailwind-merge": "^3.5.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "zustand": "^5.0.13"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/apps/dashboard/stores/metric-store.ts
+++ b/apps/dashboard/stores/metric-store.ts
@@ -1,0 +1,32 @@
+import { create } from 'zustand'
+import { MetricStore } from '@/types/metric'
+
+/*
+    ====EXAMPLE USAGE====
+    const cpuMetrics = useMetricStore(
+        (state) => {
+            state.seriesByKey[`${resourceId}:cpu`] ?? []
+        }
+    );
+*/
+
+ export const useMetricStore = create<MetricStore>(
+    (set) => ({
+        seriesByKey: {},
+
+        addMetric: (metric) => {
+            const key = `${metric.resource_id}:${metric.metricType}`;
+
+            set((state) => ({
+                seriesByKey: {
+                    ...state.seriesByKey,
+
+                    [key]: [
+                        ...(state.seriesByKey[key] ?? []),
+                        metric,
+                    ]
+                },
+            }));
+        }
+    })
+ )

--- a/apps/dashboard/types/metric-dto.ts
+++ b/apps/dashboard/types/metric-dto.ts
@@ -1,0 +1,11 @@
+export type MetricDTO = {
+  metric_id: string;
+  recorded_at: string; 
+  environment_id: string;
+  resource_id: string;
+  service_category: string;
+  usage_amount: number;
+  usage_unit: string;
+  cost_amount: number;
+  currency: string;
+};

--- a/apps/dashboard/types/metric.ts
+++ b/apps/dashboard/types/metric.ts
@@ -1,0 +1,14 @@
+export type MetricType = "cpu" | "memory" | "disk" | "cost";
+
+export type Metric = {
+    resource_id: string,
+    metricType: MetricType,
+    timestamp: string,
+    value: number
+}
+
+export type MetricStore = {
+    seriesByKey: Record<string, Metric[]>;
+
+    addMetric: (metric: Metric) => void;
+}


### PR DESCRIPTION
I am going to do this in small increments so small PRs to make sure everyone is on board. Part of #202 

In this PR I just define some typescript types to be used throughout the dashboard for metrics including
- `MetricDTO` for validating SSE/REST metric transfer
- `MetricType` resource type this metric is describinig
- `Metric` representation for dashboard metrics, `value` is the data point to be visualized by graphs
- `MetricStore` aggregation of `Metric` types hashed by `resource_id`, Zustand store of this type

Quick intro to zustand:
https://zustand.docs.pmnd.rs/learn/getting-started/introduction