### PR TITLE
Added additional configurability and instance capabilities

### DIFF
--- a/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/connector/AccountScope.java
+++ b/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/connector/AccountScope.java
@@ -1,5 +1,7 @@
 package com.cloudsherpa.ingestion.connector;
 
+import java.util.List;
+
 public class AccountScope {
   private String provider;
   private String accountId; // AWS
@@ -7,6 +9,7 @@ public class AccountScope {
   private String projectId; // GCP
 
   private String billingAccountId;
+  private List<ServiceScope> serviceScopes;// the service and related metrics that will be fetched
 
   public String getProvider() {
     return provider;
@@ -47,4 +50,13 @@ public class AccountScope {
   public void setBillingAccountId(String billingAccountId) {
     this.billingAccountId = billingAccountId;
   }
+
+  public List<ServiceScope> getServiceScopes() {
+    return serviceScopes;
+  }
+
+  public void setServiceScopes(List<ServiceScope> scopes) {
+    this.serviceScopes = scopes;
+  }
+
 }

--- a/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/connector/InstanceScope.java
+++ b/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/connector/InstanceScope.java
@@ -1,0 +1,24 @@
+package com.cloudsherpa.ingestion.connector;
+
+import java.util.List;
+
+public class InstanceScope {
+  private String identifierName; // instanceID, ClusterName, DBInstanceIdentifier etc.
+  private List<String> values; // i-21xxxxx, i-35xxxxx etc.
+
+  public String getIdentifierName() {
+    return identifierName;
+  }
+
+  public void setIdentifierName(String name) {
+    this.identifierName = name;
+  }
+
+  public List<String> getValues() {
+    return values;
+  }
+
+  public void setValues(List<String> values) {
+    this.values = values;
+  }
+}

--- a/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/connector/ServiceScope.java
+++ b/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/connector/ServiceScope.java
@@ -1,0 +1,25 @@
+package com.cloudsherpa.ingestion.connector;
+
+import java.util.List;
+
+public class ServiceScope {
+  private String name;
+
+  private List<String> metrics;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public List<String> getMetrics() {
+    return metrics;
+  }
+
+  public void setMetrics(List<String> metrics) {
+    this.metrics = metrics;
+  }
+}

--- a/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/connector/ServiceScope.java
+++ b/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/connector/ServiceScope.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public class ServiceScope {
   private String name;
-
+  private List<InstanceScope> instances;
   private List<String> metrics;
 
   public String getName() {
@@ -13,6 +13,14 @@ public class ServiceScope {
 
   public void setName(String name) {
     this.name = name;
+  }
+
+  public List<InstanceScope> getInstances() {
+    return this.instances;
+  }
+
+  public void setInstances(List<InstanceScope> instances) {
+    this.instances = instances;
   }
 
   public List<String> getMetrics() {

--- a/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/connector/UsageCapable.java
+++ b/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/connector/UsageCapable.java
@@ -5,5 +5,5 @@ import java.util.List;
 
 public interface UsageCapable {
 
-  List<UsageRecordModel> fetchUsage(AccountScope scope, IngestionRequestEvent request);
+  List<UsageRecordModel> fetchUsage(IngestionRequestEvent request);
 }

--- a/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/models/IngestionRequestEvent.java
+++ b/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/models/IngestionRequestEvent.java
@@ -13,6 +13,7 @@ public class IngestionRequestEvent {
 
   private Instant from;
   private Instant to;
+  private Integer period;
 
   private boolean includeBilling;
   private boolean includeUsage;
@@ -43,6 +44,14 @@ public class IngestionRequestEvent {
 
   public Instant getTo() {
     return to;
+  }
+
+  public void setPeriod(Integer period) {
+    this.period = period;
+  }
+
+  public Integer getPeriod() {
+    return period;
   }
 
   public void setTo(Instant to) {

--- a/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/provider/aws/AwsCloudConnector.java
+++ b/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/provider/aws/AwsCloudConnector.java
@@ -1,54 +1,94 @@
 package com.cloudsherpa.ingestion.provider.aws;
 
-import org.springframework.stereotype.Component;
-
-import java.util.List;
-
 import com.cloudsherpa.ingestion.connector.*;
 import com.cloudsherpa.ingestion.models.*;
 
+import java.time.Instant;
+import java.util.*;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 import software.amazon.awssdk.services.cloudwatch.model.*;
-
-import java.time.Instant;
-import java.util.*;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest;
+import software.amazon.awssdk.services.ec2.model.DescribeInstancesResponse;
+import software.amazon.awssdk.services.ec2.model.Reservation;
 
 @Component("AWS")
 public class AwsCloudConnector implements CloudConnector, UsageCapable, BillingCapable {
 
   private final CloudWatchClient client = CloudWatchClient.builder()
+      .credentialsProvider(DefaultCredentialsProvider.create())
       .region(Region.AF_SOUTH_1)
       .build();
 
-  @Override
-  public List<UsageRecordModel> fetchUsage(AccountScope scope, IngestionRequestEvent request) {
+  public List<String> getAllInstanceIds(Ec2Client ec2) {
+    List<String> instanceIds = new ArrayList<>();
 
-    GetMetricStatisticsRequest req = GetMetricStatisticsRequest.builder()
-        .namespace("AWS/EC2")
-        .metricName("CPUUtilization")
-        .startTime(request.getFrom())
-        .endTime(request.getTo())
-        .period(300)
-        .statistics(Statistic.AVERAGE)
+    DescribeInstancesRequest request = DescribeInstancesRequest.builder().build();
+
+    for (DescribeInstancesResponse page : ec2.describeInstancesPaginator(request)) {
+      for (Reservation reservation : page.reservations()) {
+        for (software.amazon.awssdk.services.ec2.model.Instance instance : reservation.instances()) {
+          instanceIds.add(instance.instanceId());
+        }
+      }
+    }
+
+    return instanceIds;
+  }
+
+  @Override
+  public List<UsageRecordModel> fetchUsage(IngestionRequestEvent request) {
+    DefaultCredentialsProvider.create();
+    Ec2Client ec2 = Ec2Client.builder()
+        .region(Region.AF_SOUTH_1)
+        .credentialsProvider(DefaultCredentialsProvider.create())
         .build();
 
+    List<String> instanceIds = getAllInstanceIds(ec2);
+
     List<UsageRecordModel> result = new ArrayList<>();
+    for (AccountScope accScope : request.getScopes()) { // one user may have multiple aws accounts, these can be
+                                                        // monitored with one request
+      for (ServiceScope serviceScope : accScope.getServiceScopes()) { // these are for services such as EC2, RDS etc.
 
-    for (Datapoint dp : client.getMetricStatistics(req).datapoints()) {
+        for (String instanceId : instanceIds) { // instances within a service e.g. i-23xxxxxxx
+          Dimension dimension = Dimension.builder().name("InstanceId").value(instanceId).build();
 
-      UsageRecordModel r = new UsageRecordModel();
-      r.setProvider("AWS");
-      r.setAccountId(scope.getAccountId());
-      r.setServiceName("EC2");
-      r.setMetricName("CPUUtilization");
-      r.setValue(dp.average());
-      r.setUnit(dp.unit().name());
-      r.setTimestamp(dp.timestamp());
-      r.setIngestionTimestamp(Instant.now());
-      r.setRecordId(UUID.randomUUID());
+          for (String metric : serviceScope.getMetrics()) { // the metrics requested, e.g. CPUUtilisation, NetworkIn,
+                                                            // NetworkOut etc.
+            GetMetricStatisticsRequest req = GetMetricStatisticsRequest.builder()
+                .namespace(serviceScope.getName())
+                .metricName(metric)
+                .startTime(request.getFrom())
+                .endTime(request.getTo())
+                .period(600)
+                .dimensions(dimension)
+                .statistics(Statistic.AVERAGE)
+                .build();
 
-      result.add(r);
+            for (Datapoint dp : client.getMetricStatistics(req).datapoints()) {
+
+              UsageRecordModel r = new UsageRecordModel();
+              r.setProvider(accScope.getProvider());
+              r.setAccountId(accScope.getAccountId());
+              r.setServiceName(serviceScope.getName());
+              r.setMetricName(metric);
+              r.setValue(dp.average());
+              r.setUnit(dp.unit().name());
+              r.setTimestamp(dp.timestamp());
+              r.setIngestionTimestamp(Instant.now());
+              r.setRecordId(UUID.randomUUID());
+
+              result.add(r);
+            }
+          }
+        }
+      }
     }
 
     return result;

--- a/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/provider/aws/AwsCloudConnector.java
+++ b/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/provider/aws/AwsCloudConnector.java
@@ -1,82 +1,54 @@
 package com.cloudsherpa.ingestion.provider.aws;
 
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
 import com.cloudsherpa.ingestion.connector.*;
 import com.cloudsherpa.ingestion.models.*;
-import java.util.*;
-import java.util.List;
-import org.springframework.stereotype.Component;
+
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 import software.amazon.awssdk.services.cloudwatch.model.*;
-import software.amazon.awssdk.services.ec2.Ec2Client;
-import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest;
-import software.amazon.awssdk.services.ec2.model.DescribeInstancesResponse;
-import software.amazon.awssdk.services.ec2.model.Reservation;
+
+import java.time.Instant;
+import java.util.*;
 
 @Component("AWS")
 public class AwsCloudConnector implements CloudConnector, UsageCapable, BillingCapable {
 
-  private final CloudWatchClient client =
-      CloudWatchClient.builder().region(Region.AF_SOUTH_1).build();
-
-  public List<String> getAllInstanceIds(Ec2Client ec2) {
-    List<String> instanceIds = new ArrayList<>();
-
-    DescribeInstancesRequest request = DescribeInstancesRequest.builder().build();
-
-    for (DescribeInstancesResponse page : ec2.describeInstancesPaginator(request)) {
-      for (Reservation reservation : page.reservations()) {
-        for (software.amazon.awssdk.services.ec2.model.Instance instance :
-            reservation.instances()) {
-          instanceIds.add(instance.instanceId());
-        }
-      }
-    }
-
-    return instanceIds;
-  }
+  private final CloudWatchClient client = CloudWatchClient.builder()
+      .region(Region.AF_SOUTH_1)
+      .build();
 
   @Override
   public List<UsageRecordModel> fetchUsage(AccountScope scope, IngestionRequestEvent request) {
 
-    Ec2Client ec2 = Ec2Client.builder().region(Region.AF_SOUTH_1).build();
-
-    List<String> instanceIds = getAllInstanceIds(ec2);
+    GetMetricStatisticsRequest req = GetMetricStatisticsRequest.builder()
+        .namespace("AWS/EC2")
+        .metricName("CPUUtilization")
+        .startTime(request.getFrom())
+        .endTime(request.getTo())
+        .period(300)
+        .statistics(Statistic.AVERAGE)
+        .build();
 
     List<UsageRecordModel> result = new ArrayList<>();
 
-    for (String instanceId : instanceIds) {
+    for (Datapoint dp : client.getMetricStatistics(req).datapoints()) {
 
-      Dimension dimension = Dimension.builder().name("InstanceId").value(instanceId).build();
+      UsageRecordModel r = new UsageRecordModel();
+      r.setProvider("AWS");
+      r.setAccountId(scope.getAccountId());
+      r.setServiceName("EC2");
+      r.setMetricName("CPUUtilization");
+      r.setValue(dp.average());
+      r.setUnit(dp.unit().name());
+      r.setTimestamp(dp.timestamp());
+      r.setIngestionTimestamp(Instant.now());
+      r.setRecordId(UUID.randomUUID());
 
-      GetMetricStatisticsRequest req =
-          GetMetricStatisticsRequest.builder()
-              .namespace("AWS/EC2")
-              .metricName("CPUUtilization")
-              .dimensions(dimension)
-              .startTime(request.getFrom())
-              .endTime(request.getTo())
-              .period(600)
-              .statistics(Statistic.AVERAGE)
-              .build();
-
-      GetMetricStatisticsResponse response = client.getMetricStatistics(req);
-
-      System.out.println("Instance IDs: " + instanceIds);
-      System.out.println("Datapoints: " + response.datapoints().size());
-      for (Datapoint dp : response.datapoints()) {
-
-        UsageRecordModel r = new UsageRecordModel();
-        r.setProvider("AWS");
-        r.setAccountId(scope.getAccountId());
-        r.setServiceName("EC2");
-        r.setMetricName("CPUUtilization");
-        r.setResourceId(instanceId);
-        r.setValue(dp.average());
-        r.setTimestamp(dp.timestamp());
-
-        result.add(r);
-      }
+      result.add(r);
     }
 
     return result;
@@ -98,6 +70,7 @@ public class AwsCloudConnector implements CloudConnector, UsageCapable, BillingC
   }
 
   @Override
+
   public String getProviderName() {
     return "AWS";
   }

--- a/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/provider/aws/AwsCloudConnector.java
+++ b/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/provider/aws/AwsCloudConnector.java
@@ -43,48 +43,60 @@ public class AwsCloudConnector implements CloudConnector, UsageCapable, BillingC
 
   @Override
   public List<UsageRecordModel> fetchUsage(IngestionRequestEvent request) {
+    UUID ingestionID = UUID.randomUUID();
+    int period = request.getPeriod(); // contract: ensure that the request does not return over 1000 datapoints
+                                      // ((to-from)/period)
     DefaultCredentialsProvider.create();
     Ec2Client ec2 = Ec2Client.builder()
         .region(Region.AF_SOUTH_1)
         .credentialsProvider(DefaultCredentialsProvider.create())
         .build();
 
-    List<String> instanceIds = getAllEC2InstanceIds(ec2);
-
     List<UsageRecordModel> result = new ArrayList<>();
     for (AccountScope accScope : request.getScopes()) { // one user may have multiple aws accounts, these can be
                                                         // monitored with one request
       for (ServiceScope serviceScope : accScope.getServiceScopes()) { // these are for services such as EC2, RDS etc.
 
-        for (String instanceId : instanceIds) { // instances within a service e.g. i-23xxxxxxx
-          Dimension dimension = Dimension.builder().name("InstanceId").value(instanceId).build();
+        for (InstanceScope instance : serviceScope.getInstances()) { // instances within a service with a name and value
+                                                                     // list e.g. i-23xxxxxxx
+          for (String instanceValue : instance.getValues()) { // the specific instance
+            Dimension dimension = Dimension.builder().name(instance.getIdentifierName()).value(instanceValue).build();
 
-          for (String metric : serviceScope.getMetrics()) { // the metrics requested, e.g. CPUUtilisation, NetworkIn,
-                                                            // NetworkOut etc.
-            GetMetricStatisticsRequest req = GetMetricStatisticsRequest.builder()
-                .namespace(serviceScope.getName())
-                .metricName(metric)
-                .startTime(request.getFrom())
-                .endTime(request.getTo())
-                .period(600)
-                .dimensions(dimension)
-                .statistics(Statistic.AVERAGE)
-                .build();
+            for (String metric : serviceScope.getMetrics()) { // the metrics requested, e.g. CPUUtilisation, NetworkIn,
+                                                              // NetworkOut etc.
+              GetMetricStatisticsRequest req = GetMetricStatisticsRequest.builder()
+                  .namespace(serviceScope.getName())
+                  .metricName(metric)
+                  .startTime(request.getFrom())
+                  .endTime(request.getTo())
+                  .period(period)
+                  .dimensions(dimension)
+                  .statistics(Statistic.AVERAGE)
+                  .build();
 
-            for (Datapoint dp : client.getMetricStatistics(req).datapoints()) {
+              for (Datapoint dp : client.getMetricStatistics(req).datapoints()) {
 
-              UsageRecordModel r = new UsageRecordModel();
-              r.setProvider(accScope.getProvider());
-              r.setAccountId(accScope.getAccountId());
-              r.setServiceName(serviceScope.getName());
-              r.setMetricName(metric);
-              r.setValue(dp.average());
-              r.setUnit(dp.unit().name());
-              r.setTimestamp(dp.timestamp());
-              r.setIngestionTimestamp(Instant.now());
-              r.setRecordId(UUID.randomUUID());
+                UsageRecordModel r = new UsageRecordModel();
+                r.setProvider(accScope.getProvider());
+                r.setAccountId(accScope.getAccountId());
+                r.setServiceName(serviceScope.getName());
+                r.setMetricName(metric);
+                r.setValue(dp.average());
+                r.setUnit(dp.unit().name());
+                r.setTimestamp(dp.timestamp());
+                r.setIngestionTimestamp(Instant.now());
+                r.setRecordId(UUID.randomUUID());
+                r.setResourceId(instanceValue);
+                r.setResourceType(instance.getIdentifierName());
+                r.setRegion(Region.AF_SOUTH_1.toString());
+                r.setIngestionId(ingestionID.toString());
+                r.setServiceName(serviceScope.getName());
+                r.setSource("CloudWatch");
+                r.setPeriodStart(dp.timestamp().minusSeconds(period));
+                r.setPeriodEnd(dp.timestamp());
 
-              result.add(r);
+                result.add(r);
+              }
             }
           }
         }

--- a/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/provider/aws/AwsCloudConnector.java
+++ b/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/provider/aws/AwsCloudConnector.java
@@ -25,7 +25,7 @@ public class AwsCloudConnector implements CloudConnector, UsageCapable, BillingC
       .region(Region.AF_SOUTH_1)
       .build();
 
-  public List<String> getAllInstanceIds(Ec2Client ec2) {
+  public List<String> getAllEC2InstanceIds(Ec2Client ec2) {
     List<String> instanceIds = new ArrayList<>();
 
     DescribeInstancesRequest request = DescribeInstancesRequest.builder().build();
@@ -49,7 +49,7 @@ public class AwsCloudConnector implements CloudConnector, UsageCapable, BillingC
         .credentialsProvider(DefaultCredentialsProvider.create())
         .build();
 
-    List<String> instanceIds = getAllInstanceIds(ec2);
+    List<String> instanceIds = getAllEC2InstanceIds(ec2);
 
     List<UsageRecordModel> result = new ArrayList<>();
     for (AccountScope accScope : request.getScopes()) { // one user may have multiple aws accounts, these can be

--- a/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/service/CloudUsageService.java
+++ b/apps/ingestion/src/main/java/com/cloudsherpa/ingestion/service/CloudUsageService.java
@@ -38,7 +38,7 @@ public class CloudUsageService {
       CloudConnector connector = factory.getConnector(scope.getProvider());
 
       if (request.isIncludeUsage() && connector instanceof UsageCapable usageCapable) {
-        List<UsageRecordModel> usageRecords = usageCapable.fetchUsage(scope, request);
+        List<UsageRecordModel> usageRecords = usageCapable.fetchUsage(request);
         usageResults.addAll(usageRecords);
         normalizeAndPersistUsage(usageRecords);
       }
@@ -66,7 +66,8 @@ public class CloudUsageService {
     return new IngestionResult(usageResults, billingResults);
   }
 
-  @Autowired private SherpaDbPersistenceService sherpaDbPersistenceService;
+  @Autowired
+  private SherpaDbPersistenceService sherpaDbPersistenceService;
 
   private final AwsNormalizer normalizer = new AwsNormalizer();
 
@@ -75,8 +76,7 @@ public class CloudUsageService {
       return;
     }
 
-    UUID environmentId =
-        UUID.fromString("550e8400-e29b-41d4-a716-446655440000"); // still mock for now
+    UUID environmentId = UUID.fromString("550e8400-e29b-41d4-a716-446655440000"); // still mock for now
 
     for (UsageRecordModel record : usageRecords) {
       NormalizedMetric normalized = normalizer.normalize(record);
@@ -97,23 +97,23 @@ public class CloudUsageService {
     String accountId = scope.getAccountId();
 
     String[] timestamps = {
-      "2026-05-02T18:17:00+02:00",
-      "2026-05-02T18:12:00+02:00",
-      "2026-05-02T18:07:00+02:00",
-      "2026-05-02T18:02:00+02:00",
-      "2026-05-02T17:57:00+02:00",
-      "2026-05-02T17:52:00+02:00",
-      "2026-05-02T17:47:00+02:00"
+        "2026-05-02T18:17:00+02:00",
+        "2026-05-02T18:12:00+02:00",
+        "2026-05-02T18:07:00+02:00",
+        "2026-05-02T18:02:00+02:00",
+        "2026-05-02T17:57:00+02:00",
+        "2026-05-02T17:52:00+02:00",
+        "2026-05-02T17:47:00+02:00"
     };
 
     double[] averages = {
-      1.9488974910916348,
-      1.8703353383091854,
-      2.524456273466404,
-      1.9650714832950267,
-      2.436655917725189,
-      13.769105242611008,
-      4.416415999768938
+        1.9488974910916348,
+        1.8703353383091854,
+        2.524456273466404,
+        1.9650714832950267,
+        2.436655917725189,
+        13.769105242611008,
+        4.416415999768938
     };
 
     for (int i = 0; i < timestamps.length; i++) {


### PR DESCRIPTION
Since the instances that will be monitored will be stored in the account section of the database, I added the ability to provide specific instanceIDs, and since certain services do not use the name identifier "InstanceId" I also made this field as well as the period (datapoint granularity) modifiable. The contract here is that the connector cannot return over 1440 datapoints per request (An AWS limitation). Therefore when an ingestionRequest is sent, verify that ((to-from)/period) <= 1440.

Requests still use local credentials and will continue to until real credentials can be sent from database user. 
Additional record fields now also get populated, with the following being an example of a real request and response within the extended system: 

Request: 
```bash
curl -X POST http://localhost:8080/api/events/ingest \
  -H "Content-Type: application/json" \
  -d '{
    "from": "2026-04-28T00:00:00Z",
    "to": "2026-05-05T00:00:00Z",
    "period": 600,
    "includeUsage": true,
    "includeBilling": false,
    "scopes": [
      {
        "provider": "AWS",
        "accountId": "test-account",
        "serviceScopes": [
          {
            "name": "AWS/EC2",
            "instances": [
              {
                "identifierName": "InstanceId",
                "values": [
                  "i-0ec321a1c8ed4915c"
                ]
              }
            ],
            "metrics": [
              "CPUUtilization",
              "NetworkIn",
              "NetworkOut",
              "DiskReadBytes",
              "DiskWriteBytes",
              "DiskReadOps",
              "DiskWriteOps",
              "NetworkPacketsIn",
              "NetworkPacketsOut",
              "StatusCheckFailed",
              "StatusCheckFailed_Instance",
              "StatusCheckFailed_System",
              "CPUCreditUsage",
              "CPUCreditBalance"
            ]
          }
        ]
      }
    ]
  }'
```
Unstructured Response: 
```bash
{"usage":[{"recordId":"df283536-1a62-4012-837b-a07f1bf54bbc","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUUtilization","value":10.261846776545232,"unit":"PERCENT","timestamp":"2026-05-02T15:50:00Z","periodStart":"2026-05-02T15:40:00Z","periodEnd":"2026-05-02T15:50:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.079503277Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"9ea0373c-90b4-4384-8eb1-2075ea52b92b","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUUtilization","value":1.8261568205784673,"unit":"PERCENT","timestamp":"2026-05-02T16:30:00Z","periodStart":"2026-05-02T16:20:00Z","periodEnd":"2026-05-02T16:30:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.079547818Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"f2086800-7e2e-4ac6-9762-65d79460e2e2","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUUtilization","value":1.7711234908696998,"unit":"PERCENT","timestamp":"2026-05-02T17:10:00Z","periodStart":"2026-05-02T17:00:00Z","periodEnd":"2026-05-02T17:10:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.079567253Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"1abddbc3-e235-4b55-9572-2568e1bdd153","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUUtilization","value":1.8800036813236383,"unit":"PERCENT","timestamp":"2026-05-02T16:20:00Z","periodStart":"2026-05-02T16:10:00Z","periodEnd":"2026-05-02T16:20:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.079581309Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"5aec63fd-495a-44f3-aedc-f150c7fbc815","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUUtilization","value":1.8296617954177627,"unit":"PERCENT","timestamp":"2026-05-02T17:00:00Z","periodStart":"2026-05-02T16:50:00Z","periodEnd":"2026-05-02T17:00:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.079592619Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"a02680c7-dad2-4245-9969-22c425ad539b","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUUtilization","value":2.197395805887795,"unit":"PERCENT","timestamp":"2026-05-02T16:10:00Z","periodStart":"2026-05-02T16:00:00Z","periodEnd":"2026-05-02T16:10:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.079602728Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"d6724709-4890-4e3c-8c17-fb7aadcb591c","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUUtilization","value":1.8306319483547253,"unit":"PERCENT","timestamp":"2026-05-02T16:50:00Z","periodStart":"2026-05-02T16:40:00Z","periodEnd":"2026-05-02T16:50:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.079610342Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"129977cb-50d1-484a-80cc-4d3824ace281","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUUtilization","value":2.2008637005101077,"unit":"PERCENT","timestamp":"2026-05-02T16:00:00Z","periodStart":"2026-05-02T15:50:00Z","periodEnd":"2026-05-02T16:00:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.079620540Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"2df145c2-4d19-486e-a370-82725c39b9aa","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUUtilization","value":2.2228025895235524,"unit":"PERCENT","timestamp":"2026-05-02T16:40:00Z","periodStart":"2026-05-02T16:30:00Z","periodEnd":"2026-05-02T16:40:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.079635858Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"77a31a86-63de-4850-8e7e-d88f5dc2bd7b","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkIn","value":5648.0,"unit":"BYTES","timestamp":"2026-05-02T16:10:00Z","periodStart":"2026-05-02T16:00:00Z","periodEnd":"2026-05-02T16:10:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.271208448Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"95f99db0-3658-4eb0-94e6-f88dfb82f000","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkIn","value":5660.2,"unit":"BYTES","timestamp":"2026-05-02T16:50:00Z","periodStart":"2026-05-02T16:40:00Z","periodEnd":"2026-05-02T16:50:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.271260162Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"3ec9c660-8011-4b99-bfe5-e077f1113185","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkIn","value":5675.2,"unit":"BYTES","timestamp":"2026-05-02T16:20:00Z","periodStart":"2026-05-02T16:10:00Z","periodEnd":"2026-05-02T16:20:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.271271592Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"ec8bcd31-3991-4772-aa1f-9eff82ceffcd","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkIn","value":5086.0,"unit":"BYTES","timestamp":"2026-05-02T17:00:00Z","periodStart":"2026-05-02T16:50:00Z","periodEnd":"2026-05-02T17:00:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.271286479Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"e669ff4e-9b3d-480f-98d1-a0fda0cb5633","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkIn","value":387434.14285714284,"unit":"BYTES","timestamp":"2026-05-02T15:50:00Z","periodStart":"2026-05-02T15:40:00Z","periodEnd":"2026-05-02T15:50:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.271299613Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"cc0d9586-3756-4759-9198-d4e9ebe5b1b1","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkIn","value":5932.4,"unit":"BYTES","timestamp":"2026-05-02T16:30:00Z","periodStart":"2026-05-02T16:20:00Z","periodEnd":"2026-05-02T16:30:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.271311886Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"ad2ab197-b4e9-4509-8dd9-1598b5d3add5","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkIn","value":5691.666666666667,"unit":"BYTES","timestamp":"2026-05-02T17:10:00Z","periodStart":"2026-05-02T17:00:00Z","periodEnd":"2026-05-02T17:10:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.271431543Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"a2963551-a3e2-469a-a34f-bd46634f7831","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkIn","value":5643.4,"unit":"BYTES","timestamp":"2026-05-02T16:00:00Z","periodStart":"2026-05-02T15:50:00Z","periodEnd":"2026-05-02T16:00:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.271454505Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"5ca5772d-b7c7-49db-b105-300c4920ce23","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkIn","value":5661.0,"unit":"BYTES","timestamp":"2026-05-02T16:40:00Z","periodStart":"2026-05-02T16:30:00Z","periodEnd":"2026-05-02T16:40:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.271483928Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"85f03d4b-5562-4d2f-b259-25770e3cb4c1","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkOut","value":2835.8,"unit":"BYTES","timestamp":"2026-05-02T16:10:00Z","periodStart":"2026-05-02T16:00:00Z","periodEnd":"2026-05-02T16:10:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.450798905Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"aea33fed-113e-4b74-8ce0-7855717bbaf4","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkOut","value":2868.8,"unit":"BYTES","timestamp":"2026-05-02T16:50:00Z","periodStart":"2026-05-02T16:40:00Z","periodEnd":"2026-05-02T16:50:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.450864133Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"73ec7774-26d2-4b2e-a369-1a98c5ff0273","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkOut","value":2896.2,"unit":"BYTES","timestamp":"2026-05-02T16:20:00Z","periodStart":"2026-05-02T16:10:00Z","periodEnd":"2026-05-02T16:20:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.450878880Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"016495d4-5769-4fc1-b51c-ded3bcdf9abe","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkOut","value":2585.4,"unit":"BYTES","timestamp":"2026-05-02T17:00:00Z","periodStart":"2026-05-02T16:50:00Z","periodEnd":"2026-05-02T17:00:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.450887506Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"5d2b2b58-bdb4-4c9b-b9fd-36ab7e1d1a08","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkOut","value":22217.285714285714,"unit":"BYTES","timestamp":"2026-05-02T15:50:00Z","periodStart":"2026-05-02T15:40:00Z","periodEnd":"2026-05-02T15:50:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.450899498Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"ee84f0f9-7b21-435a-bd30-c699241500b5","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkOut","value":3026.9,"unit":"BYTES","timestamp":"2026-05-02T16:30:00Z","periodStart":"2026-05-02T16:20:00Z","periodEnd":"2026-05-02T16:30:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.450911530Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"81e7c3b4-168d-4f5a-b10a-b48036dfd88f","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkOut","value":2857.3333333333335,"unit":"BYTES","timestamp":"2026-05-02T17:10:00Z","periodStart":"2026-05-02T17:00:00Z","periodEnd":"2026-05-02T17:10:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.450924153Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"62b8b93a-0735-42b7-bb3d-62d17e7f4be1","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkOut","value":2862.2,"unit":"BYTES","timestamp":"2026-05-02T16:00:00Z","periodStart":"2026-05-02T15:50:00Z","periodEnd":"2026-05-02T16:00:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.450935353Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"c728fc56-d472-44f3-a159-49a0c66202c9","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkOut","value":2853.8,"unit":"BYTES","timestamp":"2026-05-02T16:40:00Z","periodStart":"2026-05-02T16:30:00Z","periodEnd":"2026-05-02T16:40:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:32.450942827Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"474f34a1-db7c-4835-87e8-db8a7a3e759f","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkPacketsIn","value":15.0,"unit":"COUNT","timestamp":"2026-05-02T16:20:00Z","periodStart":"2026-05-02T16:10:00Z","periodEnd":"2026-05-02T16:20:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:33.778251193Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"d1d95836-66b0-4a2e-8a37-3d3609713a76","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkPacketsIn","value":13.1,"unit":"COUNT","timestamp":"2026-05-02T17:00:00Z","periodStart":"2026-05-02T16:50:00Z","periodEnd":"2026-05-02T17:00:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:33.778304179Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"1cbb9d89-ba1f-49ac-ac99-eadf452fcf23","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkPacketsIn","value":14.6,"unit":"COUNT","timestamp":"2026-05-02T16:10:00Z","periodStart":"2026-05-02T16:00:00Z","periodEnd":"2026-05-02T16:10:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:33.778318706Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"7525653a-ebc9-477f-83b6-ce471de678dc","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkPacketsIn","value":14.7,"unit":"COUNT","timestamp":"2026-05-02T16:50:00Z","periodStart":"2026-05-02T16:40:00Z","periodEnd":"2026-05-02T16:50:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:33.778331779Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"878f477f-6cd3-4b4a-ab29-3c59f7611ad6","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkPacketsIn","value":14.5,"unit":"COUNT","timestamp":"2026-05-02T16:00:00Z","periodStart":"2026-05-02T15:50:00Z","periodEnd":"2026-05-02T16:00:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:33.778340034Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"46509a93-4966-4d56-abed-b840777f9cc0","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkPacketsIn","value":14.8,"unit":"COUNT","timestamp":"2026-05-02T16:40:00Z","periodStart":"2026-05-02T16:30:00Z","periodEnd":"2026-05-02T16:40:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:33.778351335Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"6a3e613a-d14f-491f-b0bf-53aa49424bb3","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkPacketsIn","value":313.0,"unit":"COUNT","timestamp":"2026-05-02T15:50:00Z","periodStart":"2026-05-02T15:40:00Z","periodEnd":"2026-05-02T15:50:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:33.778379847Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"4892686c-31aa-4872-ab56-5356ee41d425","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkPacketsIn","value":15.9,"unit":"COUNT","timestamp":"2026-05-02T16:30:00Z","periodStart":"2026-05-02T16:20:00Z","periodEnd":"2026-05-02T16:30:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:33.778393472Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"7f388c76-dd24-4508-9e08-363293f5efe8","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkPacketsIn","value":15.333333333333334,"unit":"COUNT","timestamp":"2026-05-02T17:10:00Z","periodStart":"2026-05-02T17:00:00Z","periodEnd":"2026-05-02T17:10:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:33.778404932Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"5319ffd3-4295-41f1-b115-c45daab6ca2a","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkPacketsOut","value":15.3,"unit":"COUNT","timestamp":"2026-05-02T16:20:00Z","periodStart":"2026-05-02T16:10:00Z","periodEnd":"2026-05-02T16:20:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:33.944509849Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"50673cec-033a-4a1a-a3a0-66c858ca89e4","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkPacketsOut","value":13.3,"unit":"COUNT","timestamp":"2026-05-02T17:00:00Z","periodStart":"2026-05-02T16:50:00Z","periodEnd":"2026-05-02T17:00:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:33.944558497Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"4f6ff1b6-f455-4531-b37f-58f5bb49ac64","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkPacketsOut","value":14.3,"unit":"COUNT","timestamp":"2026-05-02T16:10:00Z","periodStart":"2026-05-02T16:00:00Z","periodEnd":"2026-05-02T16:10:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:33.944573003Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"baad3694-cf60-49ff-a475-670428bc9cd3","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkPacketsOut","value":14.8,"unit":"COUNT","timestamp":"2026-05-02T16:50:00Z","periodStart":"2026-05-02T16:40:00Z","periodEnd":"2026-05-02T16:50:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:33.944585516Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"075c44d3-5b6c-41d6-93c1-d9646356ec8e","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkPacketsOut","value":14.7,"unit":"COUNT","timestamp":"2026-05-02T16:00:00Z","periodStart":"2026-05-02T15:50:00Z","periodEnd":"2026-05-02T16:00:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:33.944597047Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"8f48c7c1-0a85-46df-9377-53948909e78a","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkPacketsOut","value":14.5,"unit":"COUNT","timestamp":"2026-05-02T16:40:00Z","periodStart":"2026-05-02T16:30:00Z","periodEnd":"2026-05-02T16:40:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:33.944604681Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"8dadd6cf-d9e9-42d6-a9a8-c9b8c9c8769b","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkPacketsOut","value":164.57142857142858,"unit":"COUNT","timestamp":"2026-05-02T15:50:00Z","periodStart":"2026-05-02T15:40:00Z","periodEnd":"2026-05-02T15:50:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:33.944616132Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"540bc77f-3023-419d-9cd3-9c27740794f7","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkPacketsOut","value":15.4,"unit":"COUNT","timestamp":"2026-05-02T16:30:00Z","periodStart":"2026-05-02T16:20:00Z","periodEnd":"2026-05-02T16:30:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:33.944628064Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"0f27153e-356d-4c61-b1a8-18f31b413b52","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"NetworkPacketsOut","value":14.666666666666666,"unit":"COUNT","timestamp":"2026-05-02T17:10:00Z","periodStart":"2026-05-02T17:00:00Z","periodEnd":"2026-05-02T17:10:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:33.944639054Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"8e205c83-6a2c-4ea2-8bd5-aff714ddceb6","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T16:20:00Z","periodStart":"2026-05-02T16:10:00Z","periodEnd":"2026-05-02T16:20:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.126256004Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"96f4d628-070f-4081-847f-304d999e209f","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T17:00:00Z","periodStart":"2026-05-02T16:50:00Z","periodEnd":"2026-05-02T17:00:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.126284906Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"12d9a68a-8d71-4b01-a09b-0caf3263d79c","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T16:10:00Z","periodStart":"2026-05-02T16:00:00Z","periodEnd":"2026-05-02T16:10:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.126306466Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"07ec3574-16b3-4a16-8aca-e212ef92896b","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T16:50:00Z","periodStart":"2026-05-02T16:40:00Z","periodEnd":"2026-05-02T16:50:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.126315893Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"f099be12-540a-432b-b384-fd0d35a23b5a","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T16:00:00Z","periodStart":"2026-05-02T15:50:00Z","periodEnd":"2026-05-02T16:00:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.126323877Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"b1143054-19de-4b37-8a0d-5a0a089720f7","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T16:40:00Z","periodStart":"2026-05-02T16:30:00Z","periodEnd":"2026-05-02T16:40:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.126333505Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"80dafc2b-cd7e-4dd4-b065-7fc4aba536a5","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T15:50:00Z","periodStart":"2026-05-02T15:40:00Z","periodEnd":"2026-05-02T15:50:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.126338614Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"50c4344d-32da-4d2f-8fb3-4e711f41a082","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T16:30:00Z","periodStart":"2026-05-02T16:20:00Z","periodEnd":"2026-05-02T16:30:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.126348732Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"c012b772-3bdb-4fc4-a16c-18f70b8e96e5","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T17:10:00Z","periodStart":"2026-05-02T17:00:00Z","periodEnd":"2026-05-02T17:10:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.126364501Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"96c81622-8e53-4249-bd0b-f996b185581c","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed_Instance","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T16:20:00Z","periodStart":"2026-05-02T16:10:00Z","periodEnd":"2026-05-02T16:20:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.367672175Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"f0b50fd3-c826-4117-872d-50256c42bc4f","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed_Instance","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T17:00:00Z","periodStart":"2026-05-02T16:50:00Z","periodEnd":"2026-05-02T17:00:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.367695578Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"38329b1e-e498-4e4b-8fda-5d2204e15eaa","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed_Instance","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T16:10:00Z","periodStart":"2026-05-02T16:00:00Z","periodEnd":"2026-05-02T16:10:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.367705466Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"47ac2ef9-a4fd-4546-b82b-a691c3398d5c","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed_Instance","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T16:50:00Z","periodStart":"2026-05-02T16:40:00Z","periodEnd":"2026-05-02T16:50:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.367713370Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"2d826f31-66ab-4a79-96dd-4e55ee7fbb33","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed_Instance","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T16:00:00Z","periodStart":"2026-05-02T15:50:00Z","periodEnd":"2026-05-02T16:00:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.367718700Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"a80505fd-ef1d-4294-9767-9736788cfd74","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed_Instance","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T16:40:00Z","periodStart":"2026-05-02T16:30:00Z","periodEnd":"2026-05-02T16:40:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.367725953Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"c7a4da99-6f07-4bdf-be53-303717ceff5e","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed_Instance","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T15:50:00Z","periodStart":"2026-05-02T15:40:00Z","periodEnd":"2026-05-02T15:50:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.367743725Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"1cdb4f74-7c1f-4c51-b358-210cd6b50718","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed_Instance","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T16:30:00Z","periodStart":"2026-05-02T16:20:00Z","periodEnd":"2026-05-02T16:30:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.367751139Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"c56b1a93-9ab4-4fcd-b744-0f409f311ee4","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed_Instance","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T17:10:00Z","periodStart":"2026-05-02T17:00:00Z","periodEnd":"2026-05-02T17:10:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.367765856Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"0936fef9-7cc1-483e-8742-38580511456f","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed_System","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T16:20:00Z","periodStart":"2026-05-02T16:10:00Z","periodEnd":"2026-05-02T16:20:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.419382108Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"f1f9652a-81f6-4ac3-be8e-cc6a139e6e6b","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed_System","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T17:00:00Z","periodStart":"2026-05-02T16:50:00Z","periodEnd":"2026-05-02T17:00:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.419416761Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"b5bb6495-0899-4638-8e13-84325fa528fb","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed_System","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T16:10:00Z","periodStart":"2026-05-02T16:00:00Z","periodEnd":"2026-05-02T16:10:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.419432971Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"a58b47a9-2421-4fd5-ae21-05ff76612972","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed_System","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T16:50:00Z","periodStart":"2026-05-02T16:40:00Z","periodEnd":"2026-05-02T16:50:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.419440555Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"293d61e8-a871-4e34-8840-e04edbc771e7","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed_System","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T16:00:00Z","periodStart":"2026-05-02T15:50:00Z","periodEnd":"2026-05-02T16:00:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.419447718Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"e7e9bc8f-7e13-4286-a503-0530b68070e3","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed_System","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T16:40:00Z","periodStart":"2026-05-02T16:30:00Z","periodEnd":"2026-05-02T16:40:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.419452426Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"b5084ed2-8e8c-49ce-bb95-175575362fd0","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed_System","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T15:50:00Z","periodStart":"2026-05-02T15:40:00Z","periodEnd":"2026-05-02T15:50:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.419458948Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"274acc87-a600-4ab7-abbd-7102ff033395","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed_System","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T16:30:00Z","periodStart":"2026-05-02T16:20:00Z","periodEnd":"2026-05-02T16:30:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.419465210Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"fe472994-c947-4bbb-884e-8e3ff9a1ff1b","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"StatusCheckFailed_System","value":0.0,"unit":"COUNT","timestamp":"2026-05-02T17:10:00Z","periodStart":"2026-05-02T17:00:00Z","periodEnd":"2026-05-02T17:10:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.419471631Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"374941df-d419-4b62-869c-1d5f8075d172","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUCreditUsage","value":0.7529200166666666,"unit":"COUNT","timestamp":"2026-05-02T16:20:00Z","periodStart":"2026-05-02T16:10:00Z","periodEnd":"2026-05-02T16:20:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.475840974Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"9a6499fd-9a65-4bfb-acd7-876637c4a4d3","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUCreditUsage","value":0.7375913583333333,"unit":"COUNT","timestamp":"2026-05-02T17:00:00Z","periodStart":"2026-05-02T16:50:00Z","periodEnd":"2026-05-02T17:00:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.475876328Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"28449435-3cbb-484e-9f31-542f799e44d5","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUCreditUsage","value":0.8908088416666666,"unit":"COUNT","timestamp":"2026-05-02T16:10:00Z","periodStart":"2026-05-02T16:00:00Z","periodEnd":"2026-05-02T16:10:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.475892988Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"b5b60072-7181-4518-a4d8-711a048de2e7","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUCreditUsage","value":0.8703349,"unit":"COUNT","timestamp":"2026-05-02T16:50:00Z","periodStart":"2026-05-02T16:40:00Z","periodEnd":"2026-05-02T16:50:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.475901724Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"46a4ece0-99b5-4fbb-85b6-a3ecb45d11f8","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUCreditUsage","value":3.068019158333333,"unit":"COUNT","timestamp":"2026-05-02T16:00:00Z","periodStart":"2026-05-02T15:50:00Z","periodEnd":"2026-05-02T16:00:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.475909188Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"547613f9-1747-4a9b-9339-97d6041e7e71","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUCreditUsage","value":0.7530145916666666,"unit":"COUNT","timestamp":"2026-05-02T16:40:00Z","periodStart":"2026-05-02T16:30:00Z","periodEnd":"2026-05-02T16:40:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.475916361Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"e59c29b8-73c1-4412-82f2-6819aef8938e","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUCreditUsage","value":2.03849515,"unit":"COUNT","timestamp":"2026-05-02T15:50:00Z","periodStart":"2026-05-02T15:40:00Z","periodEnd":"2026-05-02T15:50:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.475922151Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"729b7579-3bfa-4e0f-822f-14cb15723539","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUCreditUsage","value":0.7335380833333334,"unit":"COUNT","timestamp":"2026-05-02T16:30:00Z","periodStart":"2026-05-02T16:20:00Z","periodEnd":"2026-05-02T16:30:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.475929414Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"56289f5e-0fc8-4c56-9847-7de023e824df","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUCreditUsage","value":0.7163341,"unit":"COUNT","timestamp":"2026-05-02T17:10:00Z","periodStart":"2026-05-02T17:00:00Z","periodEnd":"2026-05-02T17:10:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.475935215Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"62af9231-94ac-4901-9eef-2fe12ef689f6","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUCreditBalance","value":4608.0,"unit":"COUNT","timestamp":"2026-05-02T16:20:00Z","periodStart":"2026-05-02T16:10:00Z","periodEnd":"2026-05-02T16:20:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.524056986Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"f96a3ff8-e416-4b85-81a8-2953fbb146f8","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUCreditBalance","value":4608.0,"unit":"COUNT","timestamp":"2026-05-02T17:00:00Z","periodStart":"2026-05-02T16:50:00Z","periodEnd":"2026-05-02T17:00:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.524082011Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"0d73e4e8-f22f-479f-bf7a-8fc5c356e10c","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUCreditBalance","value":4608.0,"unit":"COUNT","timestamp":"2026-05-02T16:10:00Z","periodStart":"2026-05-02T16:00:00Z","periodEnd":"2026-05-02T16:10:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.524087281Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"dca7a5d8-112b-460c-a169-788168974b74","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUCreditBalance","value":4608.0,"unit":"COUNT","timestamp":"2026-05-02T16:50:00Z","periodStart":"2026-05-02T16:40:00Z","periodEnd":"2026-05-02T16:50:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.524093893Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"0d1ac274-4e6e-45e9-88ca-21ae2d0a4e93","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUCreditBalance","value":4608.0,"unit":"COUNT","timestamp":"2026-05-02T16:00:00Z","periodStart":"2026-05-02T15:50:00Z","periodEnd":"2026-05-02T16:00:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.524099273Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"1bd6c099-2e45-46f3-89ed-4042fda50eb0","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUCreditBalance","value":4608.0,"unit":"COUNT","timestamp":"2026-05-02T16:40:00Z","periodStart":"2026-05-02T16:30:00Z","periodEnd":"2026-05-02T16:40:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.524103901Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"0a85dd5d-cfd5-40f9-b569-7b946ba04b5f","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUCreditBalance","value":4608.0,"unit":"COUNT","timestamp":"2026-05-02T15:50:00Z","periodStart":"2026-05-02T15:40:00Z","periodEnd":"2026-05-02T15:50:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.524110864Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"c7437571-3086-49f2-a67c-abd5588ae695","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUCreditBalance","value":4608.0,"unit":"COUNT","timestamp":"2026-05-02T16:30:00Z","periodStart":"2026-05-02T16:20:00Z","periodEnd":"2026-05-02T16:30:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.524116083Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"},{"recordId":"43fd8734-be1e-4cf8-965b-944fc82a7fb7","provider":"AWS","accountId":"test-account","subscriptionId":null,"projectId":null,"resourceId":"i-0ec321a1c8ed4915c","resourceType":"InstanceId","serviceName":"AWS/EC2","region":"af-south-1","metricName":"CPUCreditBalance","value":4608.0,"unit":"COUNT","timestamp":"2026-05-02T17:10:00Z","periodStart":"2026-05-02T17:00:00Z","periodEnd":"2026-05-02T17:10:00Z","dimensions":null,"tags":null,"ingestionTimestamp":"2026-05-12T11:44:34.524135478Z","ingestionId":"b16723be-f0a8-4548-a27c-ebe774b1173d","source":"CloudWatch"}],"billing":[]}%
```
# AWS EC2 Usage Records Summary

## Resource Information

| Field | Value |
|---|---|
| Provider | AWS |
| Service | AWS/EC2 |
| Resource ID | `i-0ec321a1c8ed4915c` |
| Resource Type | `InstanceId` |
| Region | `af-south-1` |
| Source | CloudWatch |
| Account ID | `test-account` |
| Ingestion ID | `b16723be-f0a8-4548-a27c-ebe774b1173d` |
| Time Range | 2026-05-02 15:40 UTC → 2026-05-02 17:10 UTC |

---

# Metrics Overview

## CPUUtilization

| Timestamp (UTC) | Value |
|---|---:|
| 15:50 | 10.26 % |
| 16:00 | 2.20 % |
| 16:10 | 2.20 % |
| 16:20 | 1.88 % |
| 16:30 | 1.83 % |
| 16:40 | 2.22 % |
| 16:50 | 1.83 % |
| 17:00 | 1.83 % |
| 17:10 | 1.77 % |

---

## NetworkIn

| Timestamp (UTC) | Value |
|---|---:|
| 15:50 | 387,434.14 bytes |
| 16:00 | 5,643.40 bytes |
| 16:10 | 5,648.00 bytes |
| 16:20 | 5,675.20 bytes |
| 16:30 | 5,932.40 bytes |
| 16:40 | 5,661.00 bytes |
| 16:50 | 5,660.20 bytes |
| 17:00 | 5,086.00 bytes |
| 17:10 | 5,691.67 bytes |

---

## NetworkOut

| Timestamp (UTC) | Value |
|---|---:|
| 15:50 | 22,217.29 bytes |
| 16:00 | 2,862.20 bytes |
| 16:10 | 2,835.80 bytes |
| 16:20 | 2,896.20 bytes |
| 16:30 | 3,026.90 bytes |
| 16:40 | 2,853.80 bytes |
| 16:50 | 2,868.80 bytes |
| 17:00 | 2,585.40 bytes |
| 17:10 | 2,857.33 bytes |

---

## NetworkPacketsIn

| Timestamp (UTC) | Value |
|---|---:|
| 15:50 | 313.00 packets |
| 16:00 | 14.50 packets |
| 16:10 | 14.60 packets |
| 16:20 | 15.00 packets |
| 16:30 | 15.90 packets |
| 16:40 | 14.80 packets |
| 16:50 | 14.70 packets |
| 17:00 | 13.10 packets |
| 17:10 | 15.33 packets |

---

## NetworkPacketsOut

| Timestamp (UTC) | Value |
|---|---:|
| 15:50 | 164.57 packets |
| 16:00 | 14.70 packets |
| 16:10 | 14.30 packets |
| 16:20 | 15.30 packets |
| 16:30 | 15.40 packets |
| 16:40 | 14.50 packets |
| 16:50 | 14.80 packets |
| 17:00 | 13.30 packets |
| 17:10 | 14.67 packets |

---

## Status Checks

### StatusCheckFailed

All values = `0`

### StatusCheckFailed_Instance

All values = `0`

### StatusCheckFailed_System

All values = `0`

### Observations

- No EC2 health check failures detected
- Instance appears healthy throughout the captured period

---

## CPUCreditUsage

| Timestamp (UTC) | Credits Used |
|---|---:|
| 15:50 | 2.0385 |
| 16:00 | 3.0680 |
| 16:10 | 0.8908 |
| 16:20 | 0.7529 |
| 16:30 | 0.7335 |
| 16:40 | 0.7530 |
| 16:50 | 0.8703 |
| 17:00 | 0.7376 |
| 17:10 | 0.7163 |