### PR TITLE
Code Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
   <p><strong>An AI-Driven Multi-Cloud FinOps Platform</strong></p>
 </div>
 
+![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/COS301-SE-2026/CloudSherpa?label=open%20issues)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/COS301-SE-2026/CloudSherpa/dashboard-ci.yml?label=dashboard%20build)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/COS301-SE-2026/CloudSherpa/ingestion-ci.yml?label=ingestion%20build)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/COS301-SE-2026/CloudSherpa/service-ci.yml?label=service%20build)
+![Website](https://img.shields.io/website?url=http%3A//cloudsherpa.gjjcs.org&label=cloudsherpa%20site)
+[![CloudSherpa service coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fsherpa-coverage.gjjcs.org%2Fbadges%2Fservice)](https://sherpa-coverage.gjjcs.org/badges/service)
+[![CloudSherpa dashboard coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fsherpa-coverage.gjjcs.org%2Fbadges%2Fdashboard)](https://sherpa-coverage.gjjcs.org/badges/dashboard)
+[![CloudSherpa ingestion coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fsherpa-coverage.gjjcs.org%2Fbadges%2Fingestion)](https://sherpa-coverage.gjjcs.org/badges/ingestion)
 ## Documentation
 
 For a comprehensive overview of CloudSherpa, visit our [official documentation site](https://cos301-se-2026.github.io/CloudSherpa/).

--- a/README.md
+++ b/README.md
@@ -5,14 +5,27 @@
   <p><strong>An AI-Driven Multi-Cloud FinOps Platform</strong></p>
 </div>
 
+<div style="display: flex; justify-content: center; align-items: center; flex-direction: column;">
+
+<div style="align-items: center; justify-content: center;">
+
 ![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/COS301-SE-2026/CloudSherpa?label=open%20issues)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/COS301-SE-2026/CloudSherpa/dashboard-ci.yml?label=dashboard%20build)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/COS301-SE-2026/CloudSherpa/ingestion-ci.yml?label=ingestion%20build)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/COS301-SE-2026/CloudSherpa/service-ci.yml?label=service%20build)
+
+</div>
+
+<div>
+
 ![Website](https://img.shields.io/website?url=http%3A//cloudsherpa.gjjcs.org&label=cloudsherpa%20site)
 [![CloudSherpa service coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fsherpa-coverage.gjjcs.org%2Fbadges%2Fservice)](https://sherpa-coverage.gjjcs.org/badges/service)
 [![CloudSherpa dashboard coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fsherpa-coverage.gjjcs.org%2Fbadges%2Fdashboard)](https://sherpa-coverage.gjjcs.org/badges/dashboard)
 [![CloudSherpa ingestion coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fsherpa-coverage.gjjcs.org%2Fbadges%2Fingestion)](https://sherpa-coverage.gjjcs.org/badges/ingestion)
+
+</div>
+</div>
+
 ## Documentation
 
 For a comprehensive overview of CloudSherpa, visit our [official documentation site](https://cos301-se-2026.github.io/CloudSherpa/).


### PR DESCRIPTION
Reason this took so long was the coverage. If we wanted the coverage directly from SonarQube we would have to disable login, then anyone on the internet can see our code smells and security bugs. Implemented a small service that queries for coverage server-side to prevent this.

Please let me know if you would like this underneath each other and if you are ok with splitting the build and coverage into dashboard, ingestion and service. We can do it differently, then all of our code will just have to be in one sonar project

Used shield.io for all badges. Lmk if you think I should add one of these:
- PRs closed
- Issues closed
- Contributors

<img width="1296" height="418" alt="image" src="https://github.com/user-attachments/assets/46123c3e-3b20-4551-b87e-5a652f625d31" />
