### PR TITLE
Historical data endpoint

### DIFF
--- a/apps/service/src/main/java/com/cloudsherpa/service/analytics/controller/AnalyticsController.java
+++ b/apps/service/src/main/java/com/cloudsherpa/service/analytics/controller/AnalyticsController.java
@@ -1,0 +1,51 @@
+package com.cloudsherpa.service.analytics.controller;
+
+import com.cloudsherpa.service.analytics.entities.NormalizedMetrics;
+import com.cloudsherpa.service.analytics.service.NormalizedMetricService;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/analytics")
+public class AnalyticsController {
+
+  private final NormalizedMetricService normalizedMetricService;
+
+  AnalyticsController(NormalizedMetricService normalizedMetricService) {
+    this.normalizedMetricService = normalizedMetricService;
+  }
+
+  @GetMapping("/historical")
+  /*
+   * Request params
+   *   - fromDate: ISO-8601 String, fetch metrics from
+   *   - toDate: ISO-8601 String, fetch metrics to
+   *  Curl example:
+   *   curl "localhost:8083/analytics/historical?from=2026-05-01T10:44:33.000Z&to=2026-05-02T10:44:33.106Z"
+   */
+  public ResponseEntity<?> getHistoricalData(
+      @RequestParam("from") String fromDate, @RequestParam("to") String toDate) {
+    try {
+      List<NormalizedMetrics> normalizedMetrics =
+          normalizedMetricService.fetchHistoricalData(fromDate, toDate);
+
+      if (normalizedMetrics.isEmpty()) {
+        Map<String, String> message = new HashMap<>();
+        message.put("message", "No metrics for selected window");
+        return ResponseEntity.noContent().build();
+      }
+
+      return ResponseEntity.ok(normalizedMetrics);
+    } catch (Exception e) {
+      Map<String, String> message = new HashMap<>();
+      message.put("message", e.getMessage());
+      return ResponseEntity.badRequest().build();
+    }
+  }
+}

--- a/apps/service/src/main/java/com/cloudsherpa/service/analytics/entities/NormalizedMetrics.java
+++ b/apps/service/src/main/java/com/cloudsherpa/service/analytics/entities/NormalizedMetrics.java
@@ -1,0 +1,121 @@
+package com.cloudsherpa.service.analytics.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "normalized_metrics")
+public class NormalizedMetrics {
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(name = "metric_id", nullable = false, updatable = false)
+  private UUID metricId;
+
+  @Column(name = "account_id", nullable = false)
+  private UUID accountId;
+
+  @Column(name = "resource_id", nullable = false, length = 255)
+  private UUID resourceId;
+
+  @Column(name = "recorded_at", updatable = false)
+  private OffsetDateTime recordedAt;
+
+  @Column(name = "metric_type", length = 50)
+  private String metricType;
+
+  @Column(name = "metric_name", length = 255)
+  private String metricName;
+
+  @Column(name = "metric_value", precision = 19, scale = 6)
+  private BigDecimal metricValue;
+
+  @Column(name = "unit", length = 50)
+  private String unit;
+
+  @Column(name = "currency", length = 10)
+  private String currency;
+
+  @Column(name = "period_start")
+  private OffsetDateTime periodStart;
+
+  @Column(name = "period_end")
+  private OffsetDateTime periodEnd;
+
+  public NormalizedMetrics() {
+    // Default constructor
+  }
+
+  public NormalizedMetrics(
+      UUID accountId,
+      OffsetDateTime recordedAt,
+      UUID resourceId,
+      String metricType,
+      String metricName,
+      BigDecimal metricValue,
+      String unit,
+      String currency,
+      OffsetDateTime periodStart,
+      OffsetDateTime periodEnd) {
+    this.accountId = accountId;
+    this.resourceId = resourceId;
+    this.recordedAt = recordedAt;
+    this.metricType = metricType;
+    this.metricName = metricName;
+    this.metricValue = metricValue;
+    this.unit = unit;
+    this.currency = currency;
+    this.periodStart = periodStart;
+    this.periodEnd = periodEnd;
+  }
+
+  public UUID getMetricId() {
+    return metricId;
+  }
+
+  public UUID getAccountId() {
+    return accountId;
+  }
+
+  public UUID getResourceId() {
+    return resourceId;
+  }
+
+  public OffsetDateTime getRecordedAt() {
+    return recordedAt;
+  }
+
+  public String getMetricType() {
+    return metricType;
+  }
+
+  public String getMetricName() {
+    return metricName;
+  }
+
+  public BigDecimal getMetricValue() {
+    return metricValue;
+  }
+
+  public String getUnit() {
+    return unit;
+  }
+
+  public String getCurrency() {
+    return currency;
+  }
+
+  public OffsetDateTime getPeriodStart() {
+    return periodStart;
+  }
+
+  public OffsetDateTime getPeriodEnd() {
+    return periodEnd;
+  }
+}

--- a/apps/service/src/main/java/com/cloudsherpa/service/analytics/repository/NormalizedMetricsRepository.java
+++ b/apps/service/src/main/java/com/cloudsherpa/service/analytics/repository/NormalizedMetricsRepository.java
@@ -1,0 +1,14 @@
+// Refer to EnvironmentReferenceRepository.java for most documentation
+package com.cloudsherpa.service.analytics.repository;
+
+import com.cloudsherpa.service.analytics.entities.NormalizedMetrics;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NormalizedMetricsRepository extends JpaRepository<NormalizedMetrics, UUID> {
+  // Spring translates this method name into:
+  // SELECT * FROM normalized_metrics WHERE recorded_at BETWEEN ? AND ?
+  List<NormalizedMetrics> findByRecordedAtBetween(OffsetDateTime startTime, OffsetDateTime endTime);
+}

--- a/apps/service/src/main/java/com/cloudsherpa/service/analytics/service/NormalizedMetricService.java
+++ b/apps/service/src/main/java/com/cloudsherpa/service/analytics/service/NormalizedMetricService.java
@@ -1,0 +1,38 @@
+package com.cloudsherpa.service.analytics.service;
+
+import com.cloudsherpa.service.analytics.entities.NormalizedMetrics;
+import com.cloudsherpa.service.analytics.repository.NormalizedMetricsRepository;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NormalizedMetricService {
+  private final NormalizedMetricsRepository normalizedMetricsRepository;
+
+  NormalizedMetricService(NormalizedMetricsRepository normalizedMetricsRepository) {
+    this.normalizedMetricsRepository = normalizedMetricsRepository;
+  }
+
+  public List<NormalizedMetrics> fetchHistoricalData(String from, String to) throws Exception {
+
+    OffsetDateTime parsedFromDate;
+    OffsetDateTime parsedToDate;
+
+    try {
+      parsedFromDate = OffsetDateTime.parse(from);
+      parsedToDate = OffsetDateTime.parse(to);
+    } catch (DateTimeParseException e) {
+      // Still need to log for server-side visibility
+      throw new Exception("Date Strings do not conform to ISO-8601 standard");
+    }
+
+    if (parsedFromDate.isAfter(parsedToDate)) {
+      // from after to
+      throw new Exception("Invalid interval");
+    }
+
+    return normalizedMetricsRepository.findByRecordedAtBetween(parsedFromDate, parsedToDate);
+  }
+}


### PR DESCRIPTION
Get endpoint to query DB for normalized metrics within time period configured with get params `to` and `from`. Date params are strings that are parsed to Java OffsetDateTime, hence the strings should adhere to the ISO-8601 datetime standard. Parsing failure handled gracefully with `400 Bad Request.`

Part of #39

example curl:
```sh
curl "localhost:8083/analytics/historical?from=2026-05-01T10:44:33.000Z&to=2026-05-02T10:44:33.106Z"
```