### PR TITLE
Tag docker production images for deployment

### DIFF
--- a/apps/ingestion/Dockerfile
+++ b/apps/ingestion/Dockerfile
@@ -21,6 +21,8 @@ ENTRYPOINT ["./mvnw", "spring-boot:run"]
 FROM base AS build
 
 COPY src src
+COPY config/checkstyle/checkstyle.xml config/checkstyle/checkstyle.xml
+
 RUN ./mvnw clean package -DskipTests
 
 

--- a/apps/service/Dockerfile
+++ b/apps/service/Dockerfile
@@ -21,6 +21,8 @@ ENTRYPOINT ["./mvnw", "spring-boot:run"]
 FROM base AS build
 
 COPY src src
+COPY config/checkstyle/checkstyle.xml config/checkstyle/checkstyle.xml
+
 RUN ./mvnw clean package -DskipTests
 
 

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: ../apps/ingestion
       dockerfile: Dockerfile
       target: prod
-    image: cloudsherpa-ingestion:prod
+    image: grard835/cloudsherpa-ingestion:prod
     container_name: ingestion
     ports:
       - "8081:8080"
@@ -20,7 +20,7 @@ services:
       context: ../apps/service
       dockerfile: Dockerfile
       target: prod
-    image: cloudsherpa-service:prod
+    image: grard835/cloudsherpa-service:prod
     container_name: service
     ports:
       - "8083:8080"
@@ -35,7 +35,7 @@ services:
       context: ../apps/dashboard
       dockerfile: Dockerfile
       target: prod
-    image: cloudsherpa-dashboard:prod
+    image: grard835/cloudsherpa-dashboard:prod
     container_name: dashboard
     ports:
       - "3000:3000"


### PR DESCRIPTION
Tag cloudsherpa prod images for push to dockerhub and pull from prod instance. I was able to deploy cloudsherpa to https://cloudsherpa.gjjcs.org from an AWS EC2 instance. I stopped the instance now to preserve credits and to first make cloudsherpa more reliable since it breaks very easily at the moment, but it is deployed.  