### PR TITLE
graceful error handling

### DIFF
--- a/apps/dashboard/lib/fetch/api-client.ts
+++ b/apps/dashboard/lib/fetch/api-client.ts
@@ -29,7 +29,7 @@ export default async function apiClient<T>(path: string, options?: RequestInit):
     };
     const response = await fetch(`${API_BASE}${normalizedPath}`, options);
 
-    if (response.status === 400 || response.status === 204) {
+    if (response.status === 204) {
         return [] as T;
     }
 

--- a/apps/dashboard/lib/fetch/api-client.ts
+++ b/apps/dashboard/lib/fetch/api-client.ts
@@ -29,10 +29,19 @@ export default async function apiClient<T>(path: string, options?: RequestInit):
     };
     const response = await fetch(`${API_BASE}${normalizedPath}`, options);
 
+    if (response.status === 400 || response.status === 204) {
+        return [] as T;
+    }
+
     if (!response.ok) {
         throw new Error(`Request failed with status code ${response.status}`);
     }
 
-    const result = await response.json() as T;
+    const text = await response.text();
+    if (!text) {
+        return [] as T;
+    }
+
+    const result = JSON.parse(text) as T;
     return result;
 }

--- a/apps/service/src/main/java/com/cloudsherpa/service/config/ApiSecurity.java
+++ b/apps/service/src/main/java/com/cloudsherpa/service/config/ApiSecurity.java
@@ -29,6 +29,7 @@ public class ApiSecurity {
       throws Exception {
     if (mode.equals("dev")) {
       return http.cors(cors -> cors.configurationSource(corsConfigurationSource))
+          .securityMatcher("/**")
           .csrf(csrf -> csrf.disable())
           .sessionManagement(
               session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/apps/service/src/main/java/com/cloudsherpa/service/config/AuthSecurity.java
+++ b/apps/service/src/main/java/com/cloudsherpa/service/config/AuthSecurity.java
@@ -25,6 +25,7 @@ public class AuthSecurity {
     // Different servlet filters based on dev or prod
     if (mode.equals("dev")) {
       return http.cors(cors -> cors.configurationSource(corsConfigurationSource))
+          .securityMatcher("/auth/**")
           .csrf(csrf -> csrf.disable())
           .sessionManagement(
               session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))


### PR DESCRIPTION
api-client no longer throws an error if there are no metrics, it just returns an empty array indicating no data in that time window

It shows the widgets but with no data instead of the errors