### PR TITLE
Added spinners to widget components while metrics load

### DIFF
--- a/apps/dashboard/app/dashboard/page.tsx
+++ b/apps/dashboard/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useEffect, Suspense } from "react";
 import { DateRange } from "react-day-picker";
 import { useRouter, useSearchParams } from "next/navigation";
 
+import { Spinner } from "@/components/atoms/spinner";
 import Toolbar from "@/components/dashboard/toolbar";
 import Grid from "@/components/dashboard/grid";
 import { LayoutItem, DashboardConfig, DashboardStub } from "@/types/widgets";
@@ -72,10 +73,6 @@ function DashboardContent() {
       // Leverage fact that dashboards need to be loaded into mem to trigger initial metric fetch
       await fetchResourceNames();
 
-      if (metricFetchLoad) {
-        return;
-      }
-
       if (metricFetchError) {
         setIsLoading(false);
         return;
@@ -118,7 +115,7 @@ function DashboardContent() {
     //note: reactMemo is an option for components that re-render a lot (apparently)
 
     loadDashboardData();
-  }, [setInitialState, setActiveDashboard, router, dashboards, fetchResourceNames, urlId, createDefaultWidgetConfig, metricFetchLoad, metricFetchError]);
+  }, [setInitialState, setActiveDashboard, router, dashboards, fetchResourceNames, urlId, createDefaultWidgetConfig, metricFetchError]);
 
   // sync Zustand store when the URL changes (i.e browser back/forward buttons)
   useEffect(() => {
@@ -227,9 +224,9 @@ function DashboardContent() {
       )}
 
       <main className="flex-1 overflow-y-auto overflow-x-hidden m-3 flex flex-col">
-        {isLoading || metricFetchLoad ? (
-          <div className="flex-1 flex items-center justify-center text-muted-foreground animate-pulse">
-            {metricFetchLoad ? "Loading metrics..." : "Loading dashboards..."}
+        {isLoading ? (
+          <div className="flex-1 flex items-center justify-center">
+            <Spinner className="size-8" />
           </div>
         ) : metricFetchError ? (
           <div className="flex-1 flex flex-col items-center justify-center text-center p-10">
@@ -243,6 +240,7 @@ function DashboardContent() {
             onLayoutChange={handleLayoutChange}
             layouts={widgetLayouts}
             onDeleteWidget={handleDeleteWidget}
+            metricFetchLoad={metricFetchLoad}
           />
         ) : (
           <div className="flex-1 flex flex-col items-center justify-center text-center p-10">

--- a/apps/dashboard/components/atoms/spinner.tsx
+++ b/apps/dashboard/components/atoms/spinner.tsx
@@ -1,0 +1,15 @@
+import { LoaderCircle } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+function Spinner({ className, ...props }: React.ComponentProps<typeof LoaderCircle>) {
+  return (
+    <LoaderCircle
+      data-slot="spinner"
+      className={cn("animate-spin text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export { Spinner };

--- a/apps/dashboard/components/dashboard/grid.tsx
+++ b/apps/dashboard/components/dashboard/grid.tsx
@@ -12,6 +12,7 @@ interface GridProps {
   onLayoutChange: (layout: LayoutItem[]) => void;
   layouts: LayoutItem[];
   onDeleteWidget: (layoutId: string, widgetId: string) => void;
+  metricFetchLoad: boolean;
 }
 
 export default function Grid({
@@ -20,6 +21,7 @@ export default function Grid({
   onLayoutChange,
   layouts,
   onDeleteWidget,
+  metricFetchLoad,
 }: GridProps) {
   const gridRef = useRef<HTMLDivElement>(null);
   const gridStackInstance = useRef<GridStack | null>(null);
@@ -144,6 +146,7 @@ export default function Grid({
             layout={l} 
             isEditMode={isEditMode} 
             onDeleteWidget={onDeleteWidget}
+            metricFetchLoad={metricFetchLoad}
           />
         ))}
       </div>

--- a/apps/dashboard/components/molecules/widgetWrapper.tsx
+++ b/apps/dashboard/components/molecules/widgetWrapper.tsx
@@ -9,9 +9,10 @@ interface WidgetWrapperProps {
   layout: LayoutItem;
   isEditMode: boolean;
   onDeleteWidget: (layoutId: string, widgetId: string) => void;
+  metricFetchLoad: boolean;
 }
 
-export const WidgetWrapper = ({ layout, isEditMode, onDeleteWidget }: WidgetWrapperProps) => {
+export const WidgetWrapper = ({ layout, isEditMode, onDeleteWidget, metricFetchLoad }: WidgetWrapperProps) => {
   const { id, widgetId, x, y, w, h, autoPosition } = layout;
   const config = useDashboardStore((state: DashboardStore) => state.widgets[widgetId]);
 
@@ -43,6 +44,7 @@ export const WidgetWrapper = ({ layout, isEditMode, onDeleteWidget }: WidgetWrap
         )}>
           <ConfigurableWidget 
             initialConfig={config}
+            metricFetchLoad={metricFetchLoad}
           />
         </div>
       </div>

--- a/apps/dashboard/components/widgets/changeChart.tsx
+++ b/apps/dashboard/components/widgets/changeChart.tsx
@@ -8,10 +8,12 @@ import { WidgetConfig, WidgetConfigData } from './widgetConfig';
 
 interface ConfigurableWidgetProps{
     readonly initialConfig: WidgetConfigData;
+    readonly metricFetchLoad?: boolean;
 }
 
 export function ConfigurableWidget({
     initialConfig,
+    metricFetchLoad = false,
 }: ConfigurableWidgetProps){
     const [isConfigOpen, setIsConfigOpen] = useState(false);
     const [config, setConfig] = useState<WidgetConfigData>(initialConfig);
@@ -25,6 +27,7 @@ export function ConfigurableWidget({
             resourceId: config.resourceId,
             title: config.title,
             metricType: config.metricType,
+            metricFetchLoad,
         };
 
         if(config.widgetType === 'gauge'){

--- a/apps/dashboard/components/widgets/charts/GaugeChart.tsx
+++ b/apps/dashboard/components/widgets/charts/GaugeChart.tsx
@@ -1,4 +1,5 @@
 "use client"
+import { Spinner } from "@/components/atoms/spinner";
 import { echarts } from "@/lib/charts/echarts";
 import { useMetricStore } from "@/stores/metric-store";
 import { metricSeriesToArray, MetricType } from "@/types/metric";
@@ -9,12 +10,14 @@ type GaugeWidgetProps = {
     title: string,
     resourceId?: string,
     metricType?: MetricType,
+    metricFetchLoad?: boolean,
 }
 
 export function GaugeWidget({
     title,
     resourceId,
     metricType,
+    metricFetchLoad = false,
 
 }: Readonly<GaugeWidgetProps>){
     const chartRef = useRef<HTMLDivElement>(null);
@@ -221,6 +224,13 @@ export function GaugeWidget({
     }, []);
 
     return(
-        <div ref={chartRef} className="h-full w-full" />
+        <div className="relative h-full w-full">
+            <div ref={chartRef} className="h-full w-full" />
+            {metricFetchLoad && (
+                <div className="absolute inset-0 z-10 flex items-center justify-center bg-card/60 backdrop-blur-[1px]">
+                    <Spinner className="size-8" />
+                </div>
+            )}
+        </div>
     );
 }

--- a/apps/dashboard/components/widgets/charts/LineChart.tsx
+++ b/apps/dashboard/components/widgets/charts/LineChart.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { Spinner } from "@/components/atoms/spinner";
 import { echarts } from "@/lib/charts/echarts";
 import { useMetricStore } from "@/stores/metric-store";
 import { useWindowStore } from "@/stores/window-store";
@@ -11,6 +12,7 @@ type LineChartWidgetProps = {
     title: string,
     resourceId?: string,
     metricType?: MetricType,
+    metricFetchLoad?: boolean,
 }
 
 // This will be replaced by zustand store for dashboard window
@@ -23,6 +25,7 @@ export function LineChartWidget({
     title,
     resourceId,
     metricType,
+    metricFetchLoad = false,
 }: Readonly<LineChartWidgetProps>) {
     const chartRef = useRef<HTMLDivElement>(null);
     const series = useMetricStore((state) => state.seriesByKey[`${resourceId}:${metricType}`]);
@@ -179,6 +182,13 @@ export function LineChartWidget({
     }, []);
 
     return (
-        <div ref={chartRef} className="h-full w-full" />
+        <div className="relative h-full w-full">
+            <div ref={chartRef} className="h-full w-full" />
+            {metricFetchLoad && (
+                <div className="absolute inset-0 z-10 flex items-center justify-center bg-card/60 backdrop-blur-[1px]">
+                    <Spinner className="size-8" />
+                </div>
+            )}
+        </div>
     );
 }


### PR DESCRIPTION
The main reasoning behind this is to prevent time window changes from rerendering the entire dashboard. It may not be the prettiest, but its better than having your layout disappear when you select a different time window.

[Screencast from 2026-05-22 01-07-55.webm](https://github.com/user-attachments/assets/e990255d-f0ee-48dc-9ae3-b69bd645c85f)
