### PR TITLE
Production container runtime users

### DIFF
--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -38,6 +38,8 @@ COPY --from=build /app/.next ./.next
 COPY --from=build /app/public ./public
 COPY --from=build /app/next.config.* ./
 
+USER node
+
 EXPOSE 3000
 
 CMD ["npm", "start"]

--- a/apps/ingestion/Dockerfile
+++ b/apps/ingestion/Dockerfile
@@ -32,5 +32,8 @@ FROM eclipse-temurin:21-jre AS prod
 WORKDIR /app
 COPY --from=build /app/target/*.jar app.jar
 
+RUN useradd ingestionuser
+USER ingestionuser
+
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/apps/service/Dockerfile
+++ b/apps/service/Dockerfile
@@ -32,5 +32,8 @@ FROM eclipse-temurin:21-jre AS prod
 WORKDIR /app
 COPY --from=build /app/target/*.jar app.jar
 
+RUN useradd serviceuser
+USER serviceuser 
+
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
Added runtime users to production containers as a security hardening mechanism. This restricts the permissions of the container users for prod images, such that if an attacker succeeds in obtaining shell access, they require at least privilege escalation before being able to perform a container escape. Left dev containers as is for debugging purposes, i.e. exec into dashboard container to audit installed packages vs what is expected. 