### PR TITLE
Feature/sse test

### DIFF
--- a/apps/service/src/main/java/com/cloudsherpa/service/analytics/controller/AnalyticsController.java
+++ b/apps/service/src/main/java/com/cloudsherpa/service/analytics/controller/AnalyticsController.java
@@ -52,7 +52,7 @@ public class AnalyticsController {
    * curl
    * "localhost:8083/analytics/historical?from=2026-05-01T10:44:33.000Z&to=2026-05-02T10:44:33.106Z"
    */
-  public ResponseEntity<?> getHistoricalData(
+  public ResponseEntity<List<NormalizedMetrics>> getHistoricalData(
       @RequestParam("from") String fromDate, @RequestParam("to") String toDate) {
     try {
       List<NormalizedMetrics> normalizedMetrics =

--- a/apps/service/src/test/java/com/cloudsherpa/service/unit/SseServiceTest.java
+++ b/apps/service/src/test/java/com/cloudsherpa/service/unit/SseServiceTest.java
@@ -1,0 +1,81 @@
+package com.cloudsherpa.service.unit;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cloudsherpa.service.sse.SseService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@ExtendWith(MockitoExtension.class)
+class SseServiceTest {
+
+  @Test
+  void serviceSubscribeReturnsNonNull() {
+    SseService service = new SseService();
+    service.start();
+
+    SseEmitter emitter = service.subscribe();
+    assertNotNull(emitter);
+  }
+
+  // Lifecycle tests
+  @Test
+  void serviceIsRunningAfterStart() {
+    SseService service = new SseService();
+    service.start();
+
+    assertTrue(service.isRunning());
+  }
+
+  @Test
+  void serviceIsNotRunningAfterStop() {
+    SseService service = new SseService();
+    service.start();
+    service.stop();
+
+    assertFalse(service.isRunning());
+  }
+
+  @Test
+  void subscribeReturnsNullAfterStop() {
+    SseService service = new SseService();
+    service.start();
+    service.subscribe();
+    service.stop();
+
+    assertNull(service.subscribe());
+  }
+
+  // Broadcast tests. These are weak, but do not want to refactor SseService just to make
+  // it easier to test. If broadcast ever needs to return indication of succesfull emit to
+  // callers then we test properly
+  @Test
+  void broadCastReturnsWhenNotRunning() {
+    SseService service = new SseService();
+    service.stop();
+
+    assertDoesNotThrow(() -> service.broadcast("event", "data"));
+  }
+
+  @Test
+  void broadcastDoesNotThrowWhenValidArgs() {
+    SseService service = new SseService();
+    service.start();
+
+    assertDoesNotThrow(() -> service.broadcast("event", "data"));
+  }
+
+  @Test
+  void broadcastExceptionHandledInvalidArgs() {
+    SseService service = new SseService();
+    service.start();
+
+    assertDoesNotThrow(() -> service.broadcast(null, "data"));
+  }
+}


### PR DESCRIPTION
Closes #327 

A problem I encountered was with the `broadcast` method not producing any real side effects, i.e. it returns void and handles `IOException` internally instead of throwing. I think this is fine for production code, just difficult to test, but I also did not want refactor the method when the refactoring would be only for testability, so I just tested that no exceptions leak, in the future we might want to give callers an indication as to whether emits were successful or not, then we can test better. 

The change to the AnalyticsController is the subject of the other PR so will keep this as draft until that one is merged. 