### PR TITLE
Remove ligthouse from CI, bump up node to 24

### DIFF
--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -29,7 +29,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v4
               with:
-                node-version: 22
+                node-version: 24
                 cache: 'npm'
                 cache-dependency-path: apps/dashboard/package-lock.json
 
@@ -52,52 +52,3 @@ jobs:
               env:
                 SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
                 SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-
-            - name: Archive build
-              uses: actions/upload-artifact@v4
-              with:
-                name: dashboard-build
-                include-hidden-files: true
-                path: |
-                    apps/dashboard/.next
-                    apps/dashboard/package.json
-                    apps/dashboard/package-lock.json
-                    apps/dashboard/public
-            
-    lighthouseci:
-        runs-on: ubuntu-latest
-
-        permissions:
-            contents: read
-            pull-requests: write
-            checks: write
-
-        needs: dashboard-validate
-        defaults:
-            run:
-                working-directory: apps/dashboard
-
-        steps:
-            - name: Checkout Repo
-              uses: actions/checkout@v4
-
-            - name: Setup Node
-              uses: actions/setup-node@v4
-              with:
-                node-version: 22
-                cache: 'npm'
-                cache-dependency-path: apps/dashboard/package-lock.json
-
-            - name: Download Dashboard Build
-              uses: actions/download-artifact@v4
-              with:
-                name: dashboard-build
-                path: apps/dashboard
-
-            - name: Install Production Dependencies
-              run: npm ci --omit=dev --prefer-offline
-
-            - name: Run Lighthouse CI
-              run: npx @lhci/cli@0.15.x autorun --collect.settings.chromeFlags="--no-sandbox"
-              env:
-                  LHCI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # ==== Base ====
-FROM node:22-alpine AS base
+FROM node:24-alpine AS base
 
 WORKDIR /app
 
@@ -24,7 +24,7 @@ RUN npm run build
 
 
 # ==== Prod ====
-FROM node:22-alpine AS prod
+FROM node:24-alpine AS prod
 
 WORKDIR /app
 

--- a/apps/dashboard/package-lock.json
+++ b/apps/dashboard/package-lock.json
@@ -32,7 +32,7 @@
         "@tailwindcss/postcss": "^4",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
-        "@types/node": "^20",
+        "@types/node": "^24",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^6.0.1",
@@ -5192,12 +5192,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/react": {
@@ -11541,7 +11541,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -13730,9 +13729,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -39,7 +39,7 @@
     "@tailwindcss/postcss": "^4",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
-    "@types/node": "^20",
+    "@types/node": "^24",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6.0.1",


### PR DESCRIPTION
## Lighthouse strategy
Lighthouse is not appropriate for CI to dev. It is more suited for an E2E CI suite that is more computationally and time intensive, since we want to reap all the benefits from a lighthouse analysis, specifically performance in addition to accessibility and we require an integrated environment to do that.

However, I do not propose that we get rid of regular lighthouse checks. We should use chrome dev tools to run lighthouse checks on each page that we are developing. I was also thinking of incorporating lighthouse checks into our e2e playwright tests as this article describes:
https://unlighthouse.dev/learn-lighthouse/playwright

The checks will then run alongside the e2e tests once we configure that CI suite, reducing workflow bloat and improving the performance of the automated check

## Node version bump
Node 22 is EOL from April 2027, this would mean that a version bump would be necessary right after we have developed our system. While dependencies are sparce-ish I thought that it might be a good idea to bump it up to 24. From my manual testing, it does not seem like anything breaks. This is my bad for using wrong versions initially. 
