### PR TITLE
Added qualitygate wait flags so process exits nonzero on gate failure

### DIFF
--- a/.github/workflows/ingestion-ci.yml
+++ b/.github/workflows/ingestion-ci.yml
@@ -49,4 +49,4 @@ jobs:
               env:
                 SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
                 SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-              run: ./mvnw -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=CloudSherpa-ingestion -Dsonar.projectName='CloudSherpa Ingestion'
+              run: ./mvnw -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.qualitygate.wait=true -Dsonar.projectKey=CloudSherpa-ingestion -Dsonar.projectName='CloudSherpa Ingestion'

--- a/.github/workflows/service-ci.yml
+++ b/.github/workflows/service-ci.yml
@@ -49,4 +49,4 @@ jobs:
               env:
                 SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
                 SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-              run: ./mvnw -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=CloudSherpa-service -Dsonar.projectName='CloudSherpa Service'
+              run: ./mvnw -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.qualitygate.wait=true -Dsonar.projectKey=CloudSherpa-service -Dsonar.projectName='CloudSherpa Service'


### PR DESCRIPTION
For the ingestion and service applications, CI will now fail if the quality gate fails. The quality gate configuration can be found here:
https://sonarqube.gjjcs.org/quality_gates/show/CloudSherpa%20Gate

<img width="1459" height="311" alt="image" src="https://github.com/user-attachments/assets/4f4ff214-bac4-4951-a397-9b4a0a9b0f31" />

The gate fails when new code results in a new issue and when code duplication > 10%. This is configurable so we can discuss and determine what would be best. 

In terms of workflow changes, just added the `-Dsonar.qualitygate.wait=true` flag, which polls the server until the results of the qualitygate are retrieved. If the quality gate failed the process exits with a nonzero status code, which will then fail the check.